### PR TITLE
Bugfix for leveldb backend

### DIFF
--- a/example/leveldb_backend.c
+++ b/example/leveldb_backend.c
@@ -167,7 +167,7 @@ static int leveldb_backend_read(struct leveldb_backend *s, void *state, struct d
 	dnet_convert_io_attr(io);
 
 	data = leveldb_get(s->db, s->roptions, (const char *)io->id, DNET_ID_SIZE, &data_size, &errp);
-	if (errp)
+	if (errp || !data)
 		goto err_out_exit;
 
 	io->size = data_size;


### PR DESCRIPTION
Read of nonexistent object was returning object of length 0 instead of error.
