### PR TITLE
remove zmq.hpp include from srw.cpp

### DIFF
--- a/srw/srw.cpp
+++ b/srw/srw.cpp
@@ -33,8 +33,6 @@
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
 
-#include <zmq.hpp>
-
 #include <cocaine/context.hpp>
 #include <cocaine/logging.hpp>
 #include <cocaine/app.hpp>


### PR DESCRIPTION
It seems that zmq isn't used in srw.cpp anymore, hence removing it.
