### PR TITLE
Couple more exec_context methods to allow context manipulation.

### DIFF
--- a/bindings/cpp/session.cpp
+++ b/bindings/cpp/session.cpp
@@ -209,6 +209,16 @@ dnet_addr *exec_context::address() const
 	return m_data ? &m_data->sph.data<sph>()->addr : NULL;
 }
 
+dnet_raw_id *exec_context::src_id() const
+{
+	return m_data ? &m_data->sph.data<sph>()->src : NULL;
+}
+
+data_pointer exec_context::self() const
+{
+	return m_data ? m_data->sph : data_pointer();	
+} 
+
 bool exec_context::is_final() const
 {
 	return m_data ? (m_data->sph.data<sph>()->flags & DNET_SPH_FLAGS_FINISH) : false;

--- a/include/elliptics/result_entry.hpp
+++ b/include/elliptics/result_entry.hpp
@@ -56,8 +56,18 @@ class exec_context
 		std::string event() const;
 		// event data
 		data_pointer data() const;
-		// address of the machine emitted the reply
+
+		// access to address of the machine emitted the reply
 		dnet_addr *address() const;
+
+		// access to "return id" by which reply is routed back,
+		// allows to augment sph.src with some sub id or change it completely
+		//NOTE: dangerous, use with care
+		dnet_raw_id *src_id() const;
+
+		// get back data block of the entire request
+		data_pointer self() const; 
+
 		bool is_final() const;
 		bool is_null() const;
 


### PR DESCRIPTION
One to access and possibly change sph::src. Another one to get back an entire enclosed data block.
