### PR TITLE
Moved ID locks implementation to RBTree 

### DIFF
--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -362,9 +362,20 @@ void dnet_io_exit(struct dnet_node *n);
 
 void dnet_io_req_free(struct dnet_io_req *r);
 
+struct dnet_locks_entry {
+	struct rb_node		lock_tree_entry;
+	struct list_head	lock_list_entry;
+	pthread_mutex_t		lock;
+	pthread_cond_t		wait;
+	struct dnet_raw_id	id;
+	int			locked;
+	int			order_length;
+};
+
 struct dnet_locks {
-	int			num;
-	pthread_mutex_t		lock[0];
+	struct list_head	lock_list;
+	struct rb_root		lock_tree;
+	pthread_mutex_t		lock;
 };
 
 void dnet_locks_destroy(struct dnet_node *n);

--- a/library/locks.c
+++ b/library/locks.c
@@ -25,14 +25,20 @@
 
 void dnet_locks_destroy(struct dnet_node *n)
 {
-	int i;
+	struct dnet_locks_entry *r, *tmp;
 
 	if (n->locks) {
-		for (i = 0; i < n->locks->num; ++i) {
-			pthread_mutex_destroy(&n->locks->lock[i]);
+
+		list_for_each_entry_safe(r, tmp, &n->locks->lock_list, lock_list_entry) {
+			list_del(&r->lock_list_entry);
+			pthread_mutex_destroy(&r->lock);
+			pthread_cond_destroy(&r->wait);
+
+			if (r->lock_tree_entry.rb_parent_color) {
+				rb_erase(&r->lock_tree_entry, &n->locks->lock_tree);
+			}
 		}
 
-		free(n->locks);
 		n->locks = NULL;
 	}
 }
@@ -40,24 +46,49 @@ void dnet_locks_destroy(struct dnet_node *n)
 int dnet_locks_init(struct dnet_node *n, int num)
 {
 	int err, i;
+	struct dnet_locks_entry *entry;
 
-	n->locks = malloc(sizeof(struct dnet_locks) + num * sizeof(pthread_mutex_t));
+	n->locks = malloc(sizeof(struct dnet_locks) + num * sizeof(struct dnet_locks_entry));
 	if (!n->locks) {
 		err = -ENOMEM;
 		goto err_out_exit;
 	}
 
-	n->locks->num = num;
+	INIT_LIST_HEAD(&n->locks->lock_list);
+	n->locks->lock_tree = RB_ROOT;
 
-	for (i = 0; i < num; ++i) {
-		err = pthread_mutex_init(&n->locks->lock[i], NULL);
+	err = pthread_mutex_init(&n->locks->lock, NULL);
+	if (err) {
+		err = -err;
+		dnet_log(n, DNET_LOG_ERROR, "Could not create lock: %s [%d]\n", strerror(-err), err);
+
+		goto err_out_destroy;
+	}
+
+	entry = (struct dnet_locks_entry *) (n->locks + 1);
+
+	for (i = 0; i < num; ++i, ++entry) {
+		entry->order_length = 0;
+		entry->locked = 0;
+
+		err = pthread_mutex_init(&entry->lock, NULL);
 		if (err) {
 			err = -err;
 			dnet_log(n, DNET_LOG_ERROR, "Could not create lock %d/%d: %s [%d]\n", i, num, strerror(-err), err);
 
-			n->locks->num = i;
 			goto err_out_destroy;
 		}
+		err = pthread_cond_init(&entry->wait, NULL);
+		if (err) {
+			err = -err;
+			dnet_log(n, DNET_LOG_ERROR, "Could not create cond %d/%d: %s [%d]\n", i, num, strerror(-err), err);
+
+			pthread_mutex_destroy(&entry->lock);
+			goto err_out_destroy;
+		}
+
+		memset(&entry->lock_tree_entry, 0, sizeof(struct rb_node));
+		list_add_tail(&entry->lock_list_entry, &n->locks->lock_list);
 	}
 
 	return 0;
@@ -68,39 +99,137 @@ err_out_exit:
 	return err;
 }
 
-static unsigned int dnet_ophash_index(struct dnet_node *n, struct dnet_id *key)
+static struct dnet_locks_entry *dnet_oplock_search(struct rb_root *root, struct dnet_id *id)
 {
-	unsigned int *ptr = (unsigned int *)key->id;
-	unsigned int h = 0;
-	unsigned int i;
+	struct rb_node *node = root->rb_node;
+	struct dnet_locks_entry *entry = NULL;
+	int cmp = 1;
 
-	for (i = 0; i < sizeof(key->id) / sizeof(unsigned int); ++i) {
-		h ^= ptr[i];
+	while (node) {
+		entry = rb_entry(node, struct dnet_locks_entry, lock_tree_entry);
+
+		cmp = memcmp(entry->id.id, id->id, DNET_ID_SIZE);
+		if (cmp < 0)
+			node = node->rb_left;
+		else if (cmp > 0)
+			node = node->rb_right;
+		else
+			return entry;
 	}
 
-	return h % n->locks->num;
+	return NULL;
+}
+
+static int dnet_oplock_insert(struct rb_root *root, struct dnet_locks_entry *a)
+{
+	struct rb_node **n = &root->rb_node, *parent = NULL;
+	struct dnet_locks_entry *t;
+	int cmp;
+
+	while (*n) {
+		parent = *n;
+
+		t = rb_entry(parent, struct dnet_locks_entry, lock_tree_entry);
+
+		cmp = memcmp(t->id.id, a->id.id, DNET_ID_SIZE);
+		if (cmp < 0)
+			n = &parent->rb_left;
+		else if (cmp > 0)
+			n = &parent->rb_right;
+		else
+			return -EEXIST;
+	}
+
+	rb_link_node(&a->lock_tree_entry, parent, n);
+	rb_insert_color(&a->lock_tree_entry, root);
+	return 0;
+}
+
+static void dnet_oplock_remove(struct rb_root *root, struct dnet_locks_entry *entry)
+{
+	if (!entry->lock_tree_entry.rb_parent_color) {
+//		dnet_log(entry->st->n, DNET_LOG_ERROR, "%s: trying to remove non-existen oplock.\n",
+//			dnet_dump_id_str(entry->id.id));
+		return;
+	}
+
+	if (entry) {
+		rb_erase(&entry->lock_tree_entry, root);
+		entry->lock_tree_entry.rb_parent_color = 0;
+	}
 }
 
 void dnet_oplock(struct dnet_node *n, struct dnet_id *key)
 {
-	unsigned int idx = dnet_ophash_index(n, key);
+	struct dnet_locks_entry *entry = NULL;
 
-	pthread_mutex_lock(&n->locks->lock[idx]);
+	pthread_mutex_lock(&n->locks->lock);
+
+	entry = dnet_oplock_search(&n->locks->lock_tree, key);
+
+	if (entry) {
+		pthread_mutex_lock(&entry->lock);
+
+		++entry->order_length;
+
+		pthread_mutex_unlock(&n->locks->lock);
+
+
+		while (entry->locked) {
+			pthread_cond_wait(&entry->wait, &entry->lock);
+		}
+
+		--entry->order_length;
+		entry->locked = 1;
+
+		pthread_mutex_lock(&n->locks->lock);
+
+		pthread_mutex_unlock(&entry->lock);
+	} else if (!list_empty(&n->locks->lock_list)) {
+		entry = list_first_entry(&n->locks->lock_list, struct dnet_locks_entry, lock_list_entry);
+		list_del(&entry->lock_list_entry);
+
+		entry->locked = 1;
+		memcpy(entry->id.id, key->id, DNET_ID_SIZE);
+
+		dnet_oplock_insert(&n->locks->lock_tree, entry);
+	} else {
+		dnet_log(n, DNET_LOG_ERROR, "%s: oplock list is empty.\n", dnet_dump_id(key));
+	}
+
+	pthread_mutex_unlock(&n->locks->lock);
 }
 
 void dnet_opunlock(struct dnet_node *n, struct dnet_id *key)
 {
-	unsigned int idx = dnet_ophash_index(n, key);
+	struct dnet_locks_entry *entry = NULL;
 
-	pthread_mutex_unlock(&n->locks->lock[idx]);
+	pthread_mutex_lock(&n->locks->lock);
+
+	entry = dnet_oplock_search(&n->locks->lock_tree, key);
+
+	if (!entry) {
+		dnet_log(n, DNET_LOG_ERROR, "%s: lock not found.\n", dnet_dump_id(key));
+	} else {
+		pthread_mutex_lock(&entry->lock);
+
+		entry->locked = 0;
+
+		if (entry->order_length == 0) {
+			dnet_oplock_remove(&n->locks->lock_tree, entry);
+			list_add_tail(&entry->lock_list_entry, &n->locks->lock_list);
+		} else {
+			pthread_cond_signal(&entry->wait);
+		}
+
+		pthread_mutex_unlock(&entry->lock);
+	}
+
+	pthread_mutex_unlock(&n->locks->lock);
 }
 
-int dnet_optrylock(struct dnet_node *n, struct dnet_id *key)
+int dnet_optrylock(struct dnet_node *n __unused, struct dnet_id *key __unused)
 {
-	unsigned int idx = dnet_ophash_index(n, key);
-	int err;
-
-	err = pthread_mutex_trylock(&n->locks->lock[idx]);
-	return err;
+	return -ENOTSUP;
 }
 


### PR DESCRIPTION
Previous hash-based implementation had collisions which lead to dead locks
