### PR TITLE
Fix typo in printf format for session.cpp

### DIFF
--- a/bindings/cpp/session.cpp
+++ b/bindings/cpp/session.cpp
@@ -183,8 +183,8 @@ exec_context exec_context::parse(const data_pointer &data, error_info *error)
 
 	sph *s = data.data<sph>();
 	if (data.size() != sizeof(sph) + s->event_size + s->data_size) {
-		*error = create_error(-EINVAL, "Invalid exec_context size: %zu, must be equal to sph+event_size+data_size: %ld",
-				data.size(), sizeof(sph) + s->event_size + s->data_size);
+		*error = create_error(-EINVAL, "Invalid exec_context size: %zu, must be equal to sph+event_size+data_size: %llu",
+				data.size(), static_cast<unsigned long long>(sizeof(sph) + s->event_size + s->data_size));
 		return exec_context();
 	}
 


### PR DESCRIPTION
Fixes:
bindings/cpp/session.cpp:187:60: error: format '%ld' expects argument of type 'long int', but argument 4 has type 'uint64_t {aka long long unsigned int}' [-Werror=format]
| cc1plus: all warnings being treated as errors
| make[2]: **\* [bindings/cpp/CMakeFiles/elliptics_cpp.dir/session.cpp.o] Error 1

Signed-off-by: Samuel Stirtzel s.stirtzel@googlemail.com
