### PR TITLE
Fixed deadlock in callback.cpp

### DIFF
--- a/bindings/cpp/callback.cpp
+++ b/bindings/cpp/callback.cpp
@@ -55,10 +55,10 @@ int callback::handler(struct dnet_net_state *state, struct dnet_cmd *cmd, void *
 {
 	callback *that = reinterpret_cast<callback *>(priv);
 
+	boost::mutex::scoped_lock locker(that->m_data->lock);
+
 	bool notify = false;
 	{
-		boost::mutex::scoped_lock locker(that->m_data->lock);
-
 		if (cmd)
 			that->m_data->statuses.push_back(cmd->status);
 


### PR DESCRIPTION
boost::condition_variable::notify\* functions should be called when mutex
assotiated with conditiona variable is locked. In other case there is a
possibility of deadlock in pthread internals. In boost 1.47 problem was
solved by adding internal mutex, but there is no fixes in 1.40.

So, to solve deadlocks mutex lock is moved upper and now it's holded
during whoole callback::handler() body.
