### PR TITLE
backends.h is now being copied alright to /usr/include/elliptics when installing the dev package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ install(FILES
 	include/elliptics/result_entry.hpp
 	include/elliptics/session.hpp
 	include/elliptics/utils.hpp
+	include/elliptics/backends.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/elliptics/typedefs.h
         include/elliptics/module_backend.h
         include/elliptics/module_backend.hpp


### PR DESCRIPTION
Should have added include/elliptics/backends.h to CMakeLists.txt before. Fixed that now.
