### PR TITLE
Use new eblob 0.20.0 API

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Evgeniy Polyakov <zbr@ioremap.net>
 Build-Depends:	cdbs,
 		cmake (>= 2.6),
 		debhelper (>= 7.0.50~),
-		eblob (>= 0.19.0),
+		eblob (>= 0.20.0),
 		libboost-dev,
 		libboost-iostreams-dev,
 		libboost-program-options-dev,
@@ -26,7 +26,7 @@ XS-Python-Version: >= 2.6
 
 Package: elliptics
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, eblob (>= 0.19.0), elliptics-client (= ${Source-Version}), libcocaine-core2
+Depends: ${shlibs:Depends}, ${misc:Depends}, eblob (>= 0.20.0), elliptics-client (= ${Source-Version}), libcocaine-core2
 Replaces: elliptics-2.10, srw
 Provides: elliptics-2.10
 XB-Python-Version: >= 2.6
@@ -59,7 +59,7 @@ Description: Distributed hash table storage (debug files)
 
 Package: elliptics-dev
 Architecture: any
-Depends: elliptics-client (= ${Source-Version}), eblob
+Depends: elliptics-client (= ${Source-Version}), eblob (>= 0.20.0)
 XB-Python-Version: >= 2.6
 Description: Distributed hash table storage (includes)
  Elliptics network is a fault tolerant distributed hash table object storage.

--- a/elliptics-bf.spec
+++ b/elliptics-bf.spec
@@ -16,7 +16,7 @@ BuildRequires:	gcc44 gcc44-c++
 BuildRequires:  python-devel
 %endif
 BuildRequires:	boost-python, boost-devel, boost-iostreams, boost-thread, boost-python, boost-system
-BuildRequires:	eblob-devel >= 0.19.0
+BuildRequires:	eblob-devel >= 0.20.0
 BuildRequires:  leveldb-devel snappy-devel
 BuildRequires:	cmake msgpack-devel
 

--- a/example/file_backend.c
+++ b/example/file_backend.c
@@ -200,7 +200,7 @@ static int file_write(struct file_backend_root *r, void *state __unused, struct 
 	/* Copy data from elist to ehdr */
 	dnet_ext_list_to_hdr(&elist, &ehdr);
 
-	err = eblob_write(r->meta, &key, &ehdr, 0, ehdr_size, BLOB_DISK_CTL_OVERWRITE, 0);
+	err = eblob_write(r->meta, &key, &ehdr, 0, ehdr_size, 0);
 
 	if (err) {
 		dnet_backend_log(DNET_LOG_ERROR, "%s: FILE: %s: META WRITE: %d: %s.\n",
@@ -300,7 +300,7 @@ static int file_del(struct file_backend_root *r, void *state __unused, struct dn
 		dir, dnet_dump_id_len_raw(cmd->id.id, DNET_ID_SIZE, id));
 	remove(file);
 
-	eblob_remove(r->meta, &key, 0);
+	eblob_remove(r->meta, &key);
 
 	return 0;
 }
@@ -334,7 +334,7 @@ static int file_info(struct file_backend_root *r, void *state, struct dnet_cmd *
 	}
 	fd = err;
 
-	err = eblob_read_return(r->meta, &key, 0, EBLOB_READ_NOCSUM, &wc);
+	err = eblob_read_return(r->meta, &key, EBLOB_READ_NOCSUM, &wc);
 
 	if (!err && wc.total_data_size != ehdr_size) {
 		err = -ERANGE;
@@ -556,7 +556,7 @@ static int dnet_file_db_init(struct file_backend_root *r, struct dnet_config *c,
 	memset(&ecfg, 0, sizeof(ecfg));
 	ecfg.file = meta_path;
 	ecfg.sync = r->sync;
-	ecfg.blob_flags = EBLOB_TRY_OVERWRITE | EBLOB_OVERWRITE_COMMITS | EBLOB_NO_FREE_SPACE_CHECK;
+	ecfg.blob_flags = EBLOB_NO_FREE_SPACE_CHECK;
 	ecfg.records_in_blob = r->records_in_blob;
 	ecfg.blob_size = r->blob_size;
 	ecfg.defrag_percentage = r->defrag_percentage;


### PR DESCRIPTION
- Removed types;
- Simplified prepare/plain/commit;
- Obsoleted some flags used now by default.
