### PR TITLE
Fixed data corruption due to indexes workflow 

### DIFF
--- a/bindings/cpp/session_indexes.hpp
+++ b/bindings/cpp/session_indexes.hpp
@@ -54,20 +54,10 @@ static inline void indexes_unpack(dnet_node *node, dnet_id *id, const data_point
 	}
 }
 
-static inline dnet_id indexes_generate_id(session &sess, const dnet_id &data_id)
+static inline dnet_raw_id transform_index_id(session &sess, const dnet_raw_id &data_id)
 {
-	// TODO: Better id for storing the tree?
-	std::string key;
-	key.reserve(sizeof(data_id.id) + 5);
-	key.resize(sizeof(data_id.id));
-	memcpy(&key[0], data_id.id, sizeof(data_id.id));
-	key += "index";
-
-	dnet_id id;
-	memset(&id, 0, sizeof(id));
-
-	sess.transform(key, id);
-
+	dnet_raw_id id;
+	dnet_indexes_transform_index_id(sess.get_node().get_native(), &data_id, &id);
 	return id;
 }
 

--- a/bindings/cpp/test.cpp
+++ b/bindings/cpp/test.cpp
@@ -608,6 +608,31 @@ void test_read_recovery(session &s)
 	print_read_recovery_availability(s, id);
 }
 
+void test_indexes(session &s)
+{
+	std::vector<std::string> indexes = {
+		"fast",
+		"elliptics",
+		"distributive",
+		"reliable",
+		"falt-tolerante"
+	};
+
+	std::vector<data_pointer> data(indexes.size());
+
+	std::string key = "elliptics";
+
+	s.update_indexes(key, std::vector<std::string>(), std::vector<data_pointer>()).wait();
+	s.update_indexes(key, indexes, data).wait();
+	sync_find_indexes_result all_result = s.find_all_indexes(indexes);
+	sync_find_indexes_result any_result = s.find_any_indexes(indexes);
+
+	assert(all_result.size() == any_result.size());
+	assert(all_result.size() == 1);
+	assert(all_result[0].indexes.size() == any_result[0].indexes.size());
+	assert(all_result[0].indexes.size() == indexes.size());
+}
+
 static void memory_test(session &s)
 {
 	struct rusage start, end;
@@ -755,6 +780,8 @@ int main(int argc, char *argv[])
 		test_cache_write(s, 1000);
 		test_cache_read(s, 1000);
 		test_cache_delete(s, 1000);
+
+		test_indexes(s);
 
 //	} catch (const std::exception &e) {
 //		std::cerr << "Error occurred : " << e.what() << std::endl;

--- a/include/elliptics/interface.h
+++ b/include/elliptics/interface.h
@@ -778,9 +778,13 @@ int __attribute__((weak)) dnet_transform_node(struct dnet_node *n, const void *s
 int dnet_transform_raw(struct dnet_session *s, const void *src, uint64_t size, char *csum, unsigned int csize);
 
 /*
- * Transform source id to id where to store it's secondary indexes table
+ * Transform object id to id where to store object's secondary indexes table
  */
-void dnet_indexes_transform_id(struct dnet_session *sess, const struct dnet_id *src, struct dnet_id *id);
+void dnet_indexes_transform_object_id(struct dnet_node *node, const struct dnet_id *src, struct dnet_id *id);
+/*
+ * Transform index id to id where to store secondary index's objects table
+ */
+void dnet_indexes_transform_index_id(struct dnet_node *node, const struct dnet_raw_id *src, struct dnet_raw_id *id);
 
 int dnet_lookup_addr(struct dnet_session *s, const void *remote, int len, struct dnet_id *id, int group_id, char *dst, int dlen);
 

--- a/library/dnet_common.c
+++ b/library/dnet_common.c
@@ -57,15 +57,30 @@ int dnet_transform(struct dnet_session *s, const void *src, uint64_t size, struc
 	return dnet_transform_raw(s, src, size, (char *)id->id, sizeof(id->id));
 }
 
-void dnet_indexes_transform_id(struct dnet_session *sess, const struct dnet_id *src, struct dnet_id *id)
+static void dnet_indexes_transform_id(struct dnet_node *node, const uint8_t *src, uint8_t *id,
+				      const char *suffix, int suffix_len)
 {
-	const size_t buffer_size = sizeof(src->id) + 5;
+	const size_t buffer_size = DNET_ID_SIZE + 32;
 	char buffer[buffer_size];
 
-	memcpy(buffer, src->id, sizeof(src->id));
-	memcpy(buffer + sizeof(src->id), "index", 5);
+	memcpy(buffer, src, DNET_ID_SIZE);
+	memcpy(buffer + DNET_ID_SIZE, suffix, suffix_len);
 
-	dnet_transform(sess, buffer, buffer_size, id);
+	dnet_transform_node(node, buffer, DNET_ID_SIZE + suffix_len, id, DNET_ID_SIZE);
+}
+
+void dnet_indexes_transform_object_id(struct dnet_node *node, const struct dnet_id *src, struct dnet_id *id)
+{
+	char suffix[] = "\0object_table";
+
+	dnet_indexes_transform_id(node, src->id, id->id, suffix, sizeof(suffix));
+}
+
+void dnet_indexes_transform_index_id(struct dnet_node *node, const struct dnet_raw_id *src, struct dnet_raw_id *id)
+{
+	char suffix[] = "\0index_table";
+
+	dnet_indexes_transform_id(node, src->id, id->id, suffix, sizeof(suffix));
 }
 
 static char *dnet_cmd_strings[] = {


### PR DESCRIPTION
Changed indexes hashing algorithm to avoid data overwriting if index's
name is equal to some object name
