### PR TITLE
Expose fine-tuning knobs in Cocaine extensions.

### DIFF
--- a/cocaine/plugins/storage.cpp
+++ b/cocaine/plugins/storage.cpp
@@ -61,12 +61,31 @@ log_adapter_t::log_adapter_t(const std::shared_ptr<logging::log_t> &log, const i
 {
 }
 
+namespace {
+
+dnet_config parse_json_config(const Json::Value& args) {
+	dnet_config cfg;
+
+	std::memset(&cfg, 0, sizeof(cfg));
+
+	cfg.wait_timeout   = args.get("wait-timeout", 5).asInt();
+	cfg.check_timeout  = args.get("check-timeout", 20).asInt();
+	cfg.io_thread_num  = args.get("io-thread-num", 0).asUInt();
+	cfg.net_thread_num = args.get("net-thread-num", 0).asUInt();
+	cfg.flags          = args.get("flags", 0).asInt();
+
+	return cfg;
+}
+
+}
+
 elliptics_storage_t::elliptics_storage_t(context_t &context, const std::string &name, const Json::Value &args) :
 	category_type(context, name, args),
 	m_context(context),
 	m_log(new log_t(context, name)),
 	m_log_adapter(m_log, args.get("verbosity", DNET_LOG_ERROR).asUInt()),
-	m_node(m_log_adapter),
+	m_config(parse_json_config(args)),
+	m_node(m_log_adapter, m_config),
 	m_session(m_node)
 {
 	Json::Value nodes(args["nodes"]);

--- a/cocaine/plugins/storage.hpp
+++ b/cocaine/plugins/storage.hpp
@@ -94,6 +94,7 @@ class elliptics_storage_t : public api::storage_t
 		log_ptr m_log;
 
 		log_adapter_t m_log_adapter;
+		dnet_config m_config;
 		ioremap::elliptics::node m_node;
 		ioremap::elliptics::session m_session;
 


### PR DESCRIPTION
Allow Cocaine extensions users to configure various Elliptics client
settings, such as timeouts and thread counts.
