### PR TITLE
libelliptics_module_backend_cpp.so moved from elliptics-dev to elliptics

### DIFF
--- a/debian/elliptics-dev.install
+++ b/debian/elliptics-dev.install
@@ -2,4 +2,4 @@ usr/include/elliptics/*
 usr/lib/libelliptics.so
 usr/lib/libelliptics_client.so
 usr/lib/libelliptics_cpp.so
-usr/lib/libelliptics_module_backend_cpp.so*
+usr/lib/libelliptics_module_backend_cpp.so

--- a/debian/elliptics.install
+++ b/debian/elliptics.install
@@ -1,4 +1,5 @@
 usr/bin/dnet_ioserv
 usr/lib/libelliptics.so.*
 usr/lib/libelliptics_cocaine.so.*
+usr/lib/libelliptics_module_backend_cpp.so.*
 


### PR DESCRIPTION
ELL-148

Library was misplaced: it was included in elliptics-dev along with
versioned links to itself.
