### PR TITLE
Fixed handling of errors in multigroup callback

### DIFF
--- a/bindings/cpp/callback_p.h
+++ b/bindings/cpp/callback_p.h
@@ -407,7 +407,9 @@ class multigroup_callback
 				return false;
 			}
 			// there is no success :(
-			*error = prepare_error();
+			if (cb.statuses().empty()) {
+				*error = prepare_error();
+			}
 			return true;
 		}
 


### PR DESCRIPTION
This bug caused showing user -ENOENT instead of -ETIMEDOUT in most of cases
