### PR TITLE
Fixed invalid error for read in case if there is no state

### DIFF
--- a/library/dnet_common.c
+++ b/library/dnet_common.c
@@ -2293,6 +2293,11 @@ int dnet_mix_states(struct dnet_session *s, struct dnet_id *id, int **groupsp)
 		}
 	}
 
+	if (num == 0) {
+		free(groups);
+		return -ENXIO;
+	}
+
 	group_num = num;
 	if (group_num) {
 		qsort(weights, group_num, sizeof(struct dnet_weight), dnet_weight_compare);


### PR DESCRIPTION
dnet_mix_states sometimes returnes 0 as result, which is invalid
