### PR TITLE
Added ability to recover node by using only nodes from specified groups in dc recovery.

### DIFF
--- a/recovery/dnet_recovery
+++ b/recovery/dnet_recovery
@@ -245,8 +245,9 @@ if __name__ == '__main__':
 
     if len(ctx.groups) == 0:
         ctx.groups = ctx.routes.groups()
-        ctx.address.group_id = ctx.routes.get_address_eid(ctx.address).group_id
         log.info("No groups specified: using all available groups: {0}".format(ctx.groups))
+
+    ctx.address.group_id = ctx.routes.get_address_eid(ctx.address).group_id
 
     if recovery_type == TYPE_MERGE:
         from elliptics_recovery.types.merge import main

--- a/recovery/elliptics_recovery/types/dc.py
+++ b/recovery/elliptics_recovery/types/dc.py
@@ -338,7 +338,10 @@ def main(ctx):
     ctx.monitor.stats.counter('iterations', len(all_ranges))
 
     local_iter_result = pool.apply_async(iterate_node, (local_ranges, ))
-    iter_result = pool.imap_unordered(iterate_node, (range for range in all_ranges if range.address != g_ctx.address))
+    remote_ranges = (range for range in all_ranges
+                     if range.address != g_ctx.address and
+                        range.address.group_id in g_ctx.groups)
+    iter_result = pool.imap_unordered(iterate_node, remote_ranges)
 
     try:
         timeout = 2147483647


### PR DESCRIPTION
Now when you specifies groups for dc ( dnet_recovery dc) by -g parameter only nodes from specified groups will be used in recovering local nodes. Specifing recovering node group is not necessary.
