### PR TITLE
Python: Added __len__ to elliptics.Data

### DIFF
--- a/bindings/python/elliptics_data.cpp
+++ b/bindings/python/elliptics_data.cpp
@@ -38,6 +38,7 @@ void init_elliptcs_data() {
 		.def("__str__", &data_wrapper::to_string)
 		.def("empty", &data_wrapper::empty)
 		.def("size", &data_wrapper::size)
+		.def("__len__", &data_wrapper::size)
 	;
 }
 


### PR DESCRIPTION
Added ability to use common len() function for getting size of elliptics.Data
