### PR TITLE
Build: Fixed missing python wrapper around elliptics.core.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -26,7 +26,7 @@ include /usr/share/cdbs/1/class/python-distutils.mk
 include /usr/share/cdbs/1/class/python-module.mk
 
 binary-install/elliptics-client::
-	mv $(cdbs_python_destdir)/usr/lib/python*/site-packages/* $(cdbs_python_destdir)/../elliptics-client/$(PYTHON_LIB_PATH)/; echo -n
+	cp -r $(cdbs_python_destdir)/usr/lib/python*/site-packages/* $(cdbs_python_destdir)/../elliptics-client/$(PYTHON_LIB_PATH)/; echo -n
 	rm -rf $(cdbs_python_destdir)/usr/lib/python*/site-packages; echo -n
 
 


### PR DESCRIPTION
On lucid setup.py installs files to site-packages temporary build directory and then moves it into elliptics-client build directory. It fails with "Directory not empty" error because before that core.so was created in elliptics-client.
