### PR TITLE
Python: Use ${PYTHON_EXECUTABLE} in cmake scripts

### DIFF
--- a/cmake/Modules/FindPythonExtensionDir.cmake
+++ b/cmake/Modules/FindPythonExtensionDir.cmake
@@ -1,4 +1,4 @@
-execute_process(COMMAND python -c "from distutils import sysconfig; print sysconfig.get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}'),"
+execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c "from distutils import sysconfig; print sysconfig.get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}'),"
 	RESULT_VARIABLE ret_var
 	OUTPUT_VARIABLE PYTHON_EXTENSION_DIR
 	OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
Otherwise it's impossible to build elliptics on systems where
default python version is not 2
