### PR TITLE
Acquire GIL in python binding in async_result::get()

### DIFF
--- a/bindings/python/async_result.h
+++ b/bindings/python/async_result.h
@@ -107,7 +107,9 @@ struct python_async_result
 
 	bp::list get() {
 		py_allow_threads_scoped pythr;
-		return convert_to_list(scope->get());
+		auto res = scope->get();
+		pythr.disallow();
+		return convert_to_list(res);
 	}
 
 	void wait() {


### PR DESCRIPTION
This is required before creating python list
