### PR TITLE
Fix indexes in Python again.

### DIFF
--- a/bindings/python/src/session.py
+++ b/bindings/python/src/session.py
@@ -97,7 +97,7 @@ class Session(Session):
         """
         if type(indexes) is dict:
             datas = indexes.values()
-            indexes = indexes.values()
+            indexes = indexes.keys()
 
         return super(Session, self).update_indexes(id, indexes, datas)
 
@@ -126,6 +126,6 @@ class Session(Session):
         """
         if type(indexes) is dict:
             datas = indexes.values()
-            indexes = indexes.values()
+            indexes = indexes.keys()
 
         return super(Session, self).update_indexes_internal(id, indexes, datas)


### PR DESCRIPTION
The same fix as #309 in another methods: `update_indexes_internal` and `update_indexes`.
Sorry for opening another one issue. I did not notice the error in these functions last time.
