### PR TITLE
Monitor: Made elliptics_monitor as shared library.

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(common STATIC common.c)
 set(ECOMMON_LIBRARIES common elliptics_client)
 
 set(DNET_IOSERV_SRCS ioserv.c config.c file_backend.c backends.c eblob_backend.c)
-set(DNET_IOSERV_LIBRARIES ${ECOMMON_LIBRARIES} elliptics elliptics_cocaine elliptics_monitor dl)
+set(DNET_IOSERV_LIBRARIES ${ECOMMON_LIBRARIES} elliptics elliptics_cocaine dl)
 
 if (HAVE_MODULE_BACKEND_SUPPORT)
     list(APPEND DNET_IOSERV_SRCS

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -33,7 +33,7 @@ set_target_properties(elliptics PROPERTIES
     SOVERSION ${ELLIPTICS_VERSION_ABI}
     LINKER_LANGUAGE CXX
 )
-target_link_libraries(elliptics ${ELLIPTICS_LIBRARIES} elliptics_cocaine elliptics_cache elliptics_indexes elliptics_ids)
+target_link_libraries(elliptics ${ELLIPTICS_LIBRARIES} elliptics_cocaine elliptics_cache elliptics_indexes elliptics_ids elliptics_monitor)
 
 
 add_library(elliptics_client SHARED ${ELLIPTICS_CLIENT_SRCS})

--- a/monitor/CMakeLists.txt
+++ b/monitor/CMakeLists.txt
@@ -1,5 +1,9 @@
-ADD_LIBRARY(elliptics_monitor STATIC
+ADD_LIBRARY(elliptics_monitor SHARED
             monitor.cpp
             server.cpp
             statistics.cpp
             histogram.cpp)
+
+if(UNIX OR MINGW)
+    set_target_properties(elliptics_cache PROPERTIES COMPILE_FLAGS "-fPIC")
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,8 @@
 find_package(Boost REQUIRED COMPONENTS iostreams thread regex program_options system filesystem)
 
-set(TEST_LINK_FLAGS "-Wl,-rpath,${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_CURRENT_BINARY_DIR}/../:${CMAKE_CURRENT_BINARY_DIR}/../library:${CMAKE_CURRENT_BINARY_DIR}/../srw:${CMAKE_CURRENT_BINARY_DIR}/../bindings/cpp")
+set(TEST_LINK_FLAGS "-Wl,-rpath,${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_CURRENT_BINARY_DIR}/../:${CMAKE_CURRENT_BINARY_DIR}/../library:${CMAKE_CURRENT_BINARY_DIR}/../srw:${CMAKE_CURRENT_BINARY_DIR}/../bindings/cpp:${CMAKE_CURRENT_BINARY_DIR}/../monitor")
 set(TEST_PROPERTIES PROPERTIES LINK_FLAGS "${TEST_LINK_FLAGS}" LINKER_LANGUAGE CXX)
-set(TEST_LIBRARIES  elliptics_cpp test_common elliptics elliptics_monitor ${Boost_LIBRARIES})
+set(TEST_LIBRARIES  test_common elliptics elliptics_cpp ${Boost_LIBRARIES})
 
 add_definitions(
     -DCOCAINE_CONFIG_PATH="${CMAKE_CURRENT_SOURCE_DIR}/cocaine.conf"


### PR DESCRIPTION
It is not necessary to make it static while we didn't implement using unwind.
