### PR TITLE
Monitor: fixed losing elliptics_monitor.so via making elliptics_monitor static library with -fPIC

### DIFF
--- a/bindings/python/elliptics_session.cpp
+++ b/bindings/python/elliptics_session.cpp
@@ -434,7 +434,7 @@ public:
 	python_exec_result exec_src(const bp::api::object &id, const int src_key, const std::string &event, const std::string &data) {
 		dnet_id* raw_id = NULL;
 		dnet_id conv_id;
-		if (!id.is_none()) {
+		if (id != bp::api::object()) {
 			auto eid = elliptics_id::convert(id);
 			session::transform(eid);
 			conv_id = eid.id();

--- a/monitor/CMakeLists.txt
+++ b/monitor/CMakeLists.txt
@@ -1,9 +1,9 @@
-ADD_LIBRARY(elliptics_monitor SHARED
+ADD_LIBRARY(elliptics_monitor STATIC
             monitor.cpp
             server.cpp
             statistics.cpp
             histogram.cpp)
 
 if(UNIX OR MINGW)
-    set_target_properties(elliptics_cache PROPERTIES COMPILE_FLAGS "-fPIC")
+    set_target_properties(elliptics_monitor PROPERTIES COMPILE_FLAGS "-fPIC")
 endif()


### PR DESCRIPTION
Python: downgraded checking python object on None for boost 1.40 which doesn't support is_none() method.
