### PR TITLE
tests: Fixed path to cocaine runtime

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -6,54 +6,56 @@ import os
 import sys
 import shutil
 
-def run_test(path, test):
-	os.mkdir(path)
-	p = subprocess.Popen([test, '--path', path], stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=path)
-	result = p.communicate()
-	print(result[0])
-	print(result[1])
 
-	return p.returncode
+def run_test(path, test):
+    os.mkdir(path)
+    p = subprocess.Popen([test, '--path', path], stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=path)
+    result = p.communicate()
+    print(result[0])
+    print(result[1])
+
+    return p.returncode
+
 
 def main():
-	source_dir = sys.argv[1]
-	binary_dir = sys.argv[2]
+    source_dir = sys.argv[1]
+    binary_dir = sys.argv[2]
 
-	tests = [
-		(binary_dir, 'dnet_cpp_test'),
-		(binary_dir, 'dnet_cpp_cache_test'),
-		(binary_dir, 'dnet_cpp_srw_test')
-	]
-	print('Running {0} tests'.format(len(tests)))
+    tests = [
+        (binary_dir, 'dnet_cpp_test'),
+        (binary_dir, 'dnet_cpp_cache_test'),
+        (binary_dir, 'dnet_cpp_srw_test')
+    ]
+    print('Running {0} tests'.format(len(tests)))
 
-	tests_base_dir = binary_dir + '/result'
+    tests_base_dir = binary_dir + '/result'
 
-	if os.path.exists(tests_base_dir):
-		print('Removing path: {0}'.format(tests_base_dir))
-		shutil.rmtree(tests_base_dir)
+    if os.path.exists(tests_base_dir):
+        print('Removing path: {0}'.format(tests_base_dir))
+        shutil.rmtree(tests_base_dir)
 
-	os.mkdir(tests_base_dir)
+    os.mkdir(tests_base_dir)
 
-	all_ok = True
-	for i in xrange(0, len(tests)):
-		test = tests[i]
-		print('# Start {1} of {2}: {0}: '.format(test[1], i + 1, len(tests)))
+    all_ok = True
+    for i in xrange(0, len(tests)):
+        test = tests[i]
+        print('# Start {1} of {2}: {0}: '.format(test[1], i + 1, len(tests)))
 
-		timer_begin = time.time()
-		result = run_test(tests_base_dir + '/' + test[1], test[0] + '/' + test[1])
-		timer_end = time.time()
+        timer_begin = time.time()
+        result = run_test(tests_base_dir + '/' + test[1], test[0] + '/' + test[1])
+        timer_end = time.time()
 
-		print('# Result: {0}\t{1} sec\n'.format('Passed' if result == 0 else 'Failed', timer_end - timer_begin))
+        print('# Result: {0}\t{1} sec\n'.format('Passed' if result == 0 else 'Failed ({0})'.format(result), timer_end - timer_begin))
 
-		all_ok &= result == 0
+        all_ok &= result == 0
 
-		with tarfile.TarFile.open(tests_base_dir + '/' + test[1] + '.tar.bz2', 'w:bz2') as file:
-			file.add(tests_base_dir + '/' + test[1], test[1])
-	
-	print('Tests are finised')
-	
-	exit(0 if all_ok else 1)
+        with tarfile.TarFile.open(tests_base_dir + '/' + test[1] + '.tar.bz2', 'w:bz2') as file:
+            file.add(tests_base_dir + '/' + test[1], test[1])
+
+    print('Tests are finised')
+
+    exit(0 if all_ok else 1)
 
 if __name__ == "__main__":
-	main()
+    main()
 

--- a/tests/test_base.cpp
+++ b/tests/test_base.cpp
@@ -300,6 +300,7 @@ nodes_data::ptr start_nodes(std::ostream &debug_stream, const std::vector<config
 	std::string base_path;
 	std::string auth_cookie;
 	std::string cocaine_config_template = read_file(COCAINE_CONFIG_PATH);
+	std::string run_path;
 
 	{
 		char buffer[1024];
@@ -307,6 +308,10 @@ nodes_data::ptr start_nodes(std::ostream &debug_stream, const std::vector<config
 		snprintf(buffer, sizeof(buffer), "%04x%04x", rand(), rand());
 		buffer[sizeof(buffer) - 1] = 0;
 		auth_cookie = buffer;
+
+		snprintf(buffer, sizeof(buffer), "/tmp/elliptics-test-run-%04x/", rand());
+		buffer[sizeof(buffer) - 1] = 0;
+		run_path = buffer;
 	}
 
 	const auto ports = generate_ports(configs.size());
@@ -328,6 +333,10 @@ nodes_data::ptr start_nodes(std::ostream &debug_stream, const std::vector<config
 	}
 
 	debug_stream << "Set base directory: \"" << base_path << "\"" << std::endl;
+
+	create_directory(run_path);
+	data->run_directory = directory_handler(run_path, true);
+	debug_stream << "Set cocaine run directory: \"" << run_path << "\"" << std::endl;
 
 	std::string cocaine_remotes;
 	for (size_t j = 0; j < configs.size(); ++j) {
@@ -374,7 +383,7 @@ nodes_data::ptr start_nodes(std::ostream &debug_stream, const std::vector<config
 				{ "ELLIPTICS_REMOTES", cocaine_remotes },
 				{ "ELLIPTICS_GROUPS", "1" },
 				{ "COCAINE_LOG_PATH", server_path + "/cocaine.log" },
-				{ "COCAINE_RUN_PATH", server_path + "/run" }
+				{ "COCAINE_RUN_PATH", run_path }
 			};
 			create_cocaine_config(server_path + "/cocaine.conf", cocaine_config_template, cocaine_variables);
 

--- a/tests/test_base.hpp
+++ b/tests/test_base.hpp
@@ -154,6 +154,7 @@ struct nodes_data
 	directory_handler directory;
 	int locator_port;
 #endif // NO_SERVER
+	directory_handler run_directory;
 
 	std::unique_ptr<ioremap::elliptics::node> node;
 };


### PR DESCRIPTION
Create runtime directory in /tmp/elliptics-*, it doesn't contain
any useful information but it's length is limited by the system
