### PR TITLE
Python: fixed None usage as Id in session.exec_()

### DIFF
--- a/bindings/python/elliptics_session.cpp
+++ b/bindings/python/elliptics_session.cpp
@@ -434,7 +434,7 @@ public:
 	python_exec_result exec_src(const bp::api::object &id, const int src_key, const std::string &event, const std::string &data) {
 		dnet_id* raw_id = NULL;
 		dnet_id conv_id;
-		if (id != bp::api::object()) {
+		if (id.ptr() != Py_None) {
 			auto eid = elliptics_id::convert(id);
 			session::transform(eid);
 			conv_id = eid.id();


### PR DESCRIPTION
Check must directly compare `PyObject*` to `Py_None` singleton, because other method (checking object equality to `python::api::object()`) involves user defined comparing/equality operators.
This is the case with `elliptics.Id` which has `__cmp__` method, which cannot accept None as an argument and breaks.
