### PR TITLE
Python: clone feature and node/session deletion order (lts).

### DIFF
--- a/bindings/python/elliptics_session.cpp
+++ b/bindings/python/elliptics_session.cpp
@@ -686,7 +686,7 @@ void init_elliptics_session() {
 		.def("clone", &elliptics_session::clone,
 		     bp::return_value_policy<bp::manage_new_object>(),
 		     "clone()\n"
-		     "    Creates and returns session which is equal to currnet\n"
+		     "    Creates and returns session which is equal to current\n"
 		     "    but complitely independent from it.\n\n"
 		     "    cloned_session = session.clone()\n")
 		.def("transform", &elliptics_session::transform, (bp::args("data")),

--- a/bindings/python/src/session.py
+++ b/bindings/python/src/session.py
@@ -31,7 +31,7 @@ class Session(Session):
 
     def clone(self):
         '''
-        Creates and returns session which is equal to currnet"
+        Creates and returns session which is equal to current"
         but complitely independent from it."
 
         cloned_session = session.clone()


### PR DESCRIPTION
Added keeping node inside elliptics.Session object which guarantees right deletion order of session and node
Added ability to clone elliptics.Session
