### PR TITLE
cache: Stop lifecheck thread at node->need_exit

### DIFF
--- a/cache/cache.cpp
+++ b/cache/cache.cpp
@@ -109,18 +109,10 @@ cache_manager::cache_manager(struct dnet_node *n) {
 		m_caches.emplace_back(std::make_shared<slru_cache_t>(n, pages_max_sizes));
 	}
 
-	stop = false;
-
 	ioremap::monitor::dnet_monitor_add_provider(n, new cache_stat_provider(*this), "cache");
 }
 
 cache_manager::~cache_manager() {
-	//Stops all caches in parallel. Avoids sleeping in all cache destructors
-	size_t id = 0;
-	for (auto it(m_caches.begin()), end(m_caches.end()); it != end; ++it, ++id) {
-		(*it)->stop(); //Sets cache as stopped
-	}
-	stop = true;
 }
 
 int cache_manager::write(const unsigned char *id, dnet_net_state *st, dnet_cmd *cmd, dnet_io_attr *io, const char *data) {

--- a/cache/cache.hpp
+++ b/cache/cache.hpp
@@ -384,7 +384,6 @@ class cache_manager {
 		std::vector<std::shared_ptr<slru_cache_t>> m_caches;
 		size_t m_max_cache_size;
 		size_t m_cache_pages_number;
-		bool stop;
 
 		size_t idx(const unsigned char *id);
 };

--- a/cache/slru_cache.hpp
+++ b/cache/slru_cache.hpp
@@ -28,8 +28,6 @@ public:
 
 	~slru_cache_t();
 
-	void stop();
-
 	int write(const unsigned char *id, dnet_net_state *st, dnet_cmd *cmd, dnet_io_attr *io, const char *data);
 
 	std::shared_ptr<raw_data_t> read(const unsigned char *id, dnet_cmd *cmd, dnet_io_attr *io);
@@ -52,7 +50,6 @@ private:
 
 	time_stats_updater_t *get_time_stats_updater();
 
-	bool m_need_exit;
 	struct dnet_node *m_node;
 	std::mutex m_lock;
 	size_t m_cache_pages_number;


### PR DESCRIPTION
So lifecheck thread will stop at the same time as io/net/check
threads, so server stop will be speeded up for a bit.
