### PR TITLE
debian: elliptics-dev should depend on react-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -69,7 +69,7 @@ Description: Distributed hash table storage (debug files)
 
 Package: elliptics-dev
 Architecture: any
-Depends: elliptics-client (= ${Source-Version})
+Depends: elliptics-client (= ${Source-Version}), react-dev (>= 1.0.2)
 XB-Python-Version: >= 2.6
 Description: Distributed hash table storage (includes)
  Elliptics network is a fault tolerant distributed hash table object storage.


### PR DESCRIPTION
It's needed as react is exported as dependency of elliptics-monitoring
which is accidently a dependency of elliptics-client
