### PR TITLE
monitor: initialize monitor only for server nodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ install(FILES
 set(INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include")
 set(INSTALL_LIBRARY_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}")
 
-export(TARGETS elliptics_monitor elliptics_client elliptics_cpp
+export(TARGETS elliptics_client elliptics_cpp
     FILE "${PROJECT_BINARY_DIR}/EllipticsTargets.cmake")
 
 #export(PACKAGE Elliptics)

--- a/debian/control
+++ b/debian/control
@@ -69,7 +69,7 @@ Description: Distributed hash table storage (debug files)
 
 Package: elliptics-dev
 Architecture: any
-Depends: elliptics-client (= ${Source-Version}), react-dev (>= 1.0.2)
+Depends: elliptics-client (= ${Source-Version})
 XB-Python-Version: >= 2.6
 Description: Distributed hash table storage (includes)
  Elliptics network is a fault tolerant distributed hash table object storage.

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -42,7 +42,7 @@ set_target_properties(elliptics_client PROPERTIES
     LINKER_LANGUAGE CXX
     )
 #target_link_libraries(elliptics_client ${ELLIPTICS_LIBRARIES})
-target_link_libraries(elliptics_client ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES} elliptics_monitor)
+target_link_libraries(elliptics_client ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES})
 
 install(TARGETS elliptics
     LIBRARY DESTINATION lib${LIB_SUFFIX}

--- a/library/pool.c
+++ b/library/pool.c
@@ -938,8 +938,6 @@ int dnet_io_init(struct dnet_node *n, struct dnet_config *cfg)
 		}
 	}
 
-	dnet_monitor_init_io_stat_provider(n);
-
 	return 0;
 
 err_out_net_destroy:


### PR DESCRIPTION
It eliminates client's dependency on monitor/react
