### PR TITLE
Don't link with json

### DIFF
--- a/cocaine/plugins/CMakeLists.txt
+++ b/cocaine/plugins/CMakeLists.txt
@@ -4,7 +4,7 @@ ADD_LIBRARY(elliptics-extensions MODULE
         ../include/cocaine/services/elliptics_storage.hpp)
 
 INCLUDE_DIRECTORIES(../include)
-TARGET_LINK_LIBRARIES(elliptics-extensions ${COCAINE_LIBRARIES} elliptics_client elliptics_cpp json)
+TARGET_LINK_LIBRARIES(elliptics-extensions ${COCAINE_LIBRARIES} elliptics_client elliptics_cpp)
 
 SET_TARGET_PROPERTIES(elliptics-extensions PROPERTIES
         PREFIX ""

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -32,7 +32,7 @@ set_target_properties(elliptics PROPERTIES
     SOVERSION ${ELLIPTICS_VERSION_ABI}
     LINKER_LANGUAGE CXX
     )
-target_link_libraries(elliptics ${ELLIPTICS_LIBRARIES} elliptics_cocaine elliptics_cache elliptics_indexes elliptics_ids elliptics_monitor json)
+target_link_libraries(elliptics ${ELLIPTICS_LIBRARIES} elliptics_cocaine elliptics_cache elliptics_indexes elliptics_ids elliptics_monitor)
 
 
 add_library(elliptics_client SHARED ${ELLIPTICS_CLIENT_SRCS})


### PR DESCRIPTION
This library was a part of Cocaine.
Cocaine shouldn't build this library as shared one
