### PR TITLE
indexes: Handle failed parsed indexes metadata from msgpack

### DIFF
--- a/bindings/cpp/async_result.cpp
+++ b/bindings/cpp/async_result.cpp
@@ -218,7 +218,17 @@ bool async_result<get_index_metadata_result_entry>::get(get_index_metadata_resul
 {
 	wait(session::throw_at_get);
 	if (!m_data->results.empty()) {
-		entry = m_data->results[0];
+		entry.index_size = 0;
+		entry.is_valid = true;
+		entry.shard_id = -1;
+		for (auto it = m_data->results.begin(); it != m_data->results.end(); ++it) {
+			if (it->is_valid) {
+				entry.index_size += it->index_size;
+			} else {
+				entry.is_valid = false;
+				return false;
+			}
+		}
 		return true;
 	}
 	return false;

--- a/include/elliptics/result_entry.hpp
+++ b/include/elliptics/result_entry.hpp
@@ -260,6 +260,7 @@ struct find_indexes_result_entry
 struct get_index_metadata_result_entry
 {
 	size_t index_size;
+	int shard_id;
 	bool is_valid;
 };
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -266,6 +266,7 @@ static void test_more_indexes(session &sess)
  * - Write 256 keys to index "index"
  * - Request "index" metadata, which will consist of metadatas for each shard
  * - Sum up sizes of shards indexes and check if it equals to 256
+ * - Check if all metainformations from shards were valid
  */
 static void test_indexes_metadata(session &sess)
 {
@@ -289,6 +290,9 @@ static void test_indexes_metadata(session &sess)
 	ELLIPTICS_REQUIRE(get_index_metadata_result, sess.get_index_metadata(index));
 	sync_get_index_metadata_result metadata = get_index_metadata_result.get();
 
+	get_index_metadata_result_entry aggregated_metadata;
+	get_index_metadata_result.get(aggregated_metadata);
+
 	size_t total_index_size = 0;
 	int invalid_results_number = 0;
 	for (size_t i = 0; i < metadata.size(); ++i) {
@@ -301,6 +305,7 @@ static void test_indexes_metadata(session &sess)
 	}
 	if (invalid_results_number == 0) {
 		BOOST_REQUIRE_EQUAL(total_index_size, keys.size());
+		BOOST_REQUIRE_EQUAL(total_index_size, aggregated_metadata.index_size);
 	} else {
 		BOOST_REQUIRE_LE(total_index_size, keys.size());
 	}


### PR DESCRIPTION
If msgpack parsing is failed during metadata extraction
metadata struct will be marked as not valid
and field "is_valid" will be false
