### PR TITLE
Fix CMakeLists install section: add missing logger.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ install(FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/include/elliptics/typedefs.h
         include/elliptics/module_backend.h
         include/elliptics/module_backend.hpp
+        include/elliptics/logger.hpp
         DESTINATION include/elliptics/
         )
 


### PR DESCRIPTION
Seems `logger.hpp` should be installed with other dev stuff, as:

```
/usr/local/include/elliptics/interface.h:40:22: error: logger.hpp: No such file or directory
```
