### PR TITLE
Backport. Add read_latest to Elliptics service for Cocaine

### DIFF
--- a/cocaine/include/cocaine/framework/services/elliptics_storage.hpp
+++ b/cocaine/include/cocaine/framework/services/elliptics_storage.hpp
@@ -51,6 +51,11 @@ public:
 	bulk_read(const std::string &collection, const std::vector<std::string> &keys) {
 		return call<io::elliptics::bulk_read>(collection, keys);
 	}
+
+	service_traits<io::elliptics::cache_read>::future_type
+	cache_read_latest(const std::string &collection, const std::string &key) {
+		return call<io::elliptics::read_latest>(collection, key);
+	}
 };
 
 }} // namespace cocaine::framework

--- a/cocaine/include/cocaine/services/elliptics_storage.hpp
+++ b/cocaine/include/cocaine/services/elliptics_storage.hpp
@@ -46,6 +46,25 @@ struct cache_read
 	result_type;
 };
 
+struct read_latest
+{
+	typedef elliptics_tag tag;
+
+	typedef boost::mpl::list<
+	/* Key namespace. Currently no ACL checks are performed, so in theory any app can read
+	   any other app data without restrictions. */
+		std::string,
+	/* Key. */
+		std::string
+	> tuple_type;
+
+	typedef
+	/* The stored value. Typically it will be serialized with msgpack, but it's not a strict
+	   requirement. But as there's no way to know the format, try to unpack it anyway. */
+		std::string
+	result_type;
+};
+
 struct cache_write
 {
 	typedef elliptics_tag tag;
@@ -111,7 +130,8 @@ struct protocol<elliptics_tag> : public extends<storage_tag>
 	typedef boost::mpl::list<
 		elliptics::cache_read,
 		elliptics::cache_write,
-		elliptics::bulk_read
+		elliptics::bulk_read,
+		elliptics::read_latest
 //		elliptics::bulk_write
 	> type;
 };

--- a/cocaine/plugins/service.cpp
+++ b/cocaine/plugins/service.cpp
@@ -45,6 +45,7 @@ elliptics_service_t::elliptics_service_t(context_t &context, io::reactor_t &reac
 	on<io::elliptics::cache_read >("cache_read",  std::bind(&elliptics_service_t::cache_read,  this, _1, _2));
 	on<io::elliptics::cache_write>("cache_write", std::bind(&elliptics_service_t::cache_write, this, _1, _2, _3, _4));
 	on<io::elliptics::bulk_read  >("bulk_read",   std::bind(&elliptics_service_t::bulk_read,   this, _1, _2));
+	on<io::elliptics::read_latest>("read_latest", std::bind(&elliptics_service_t::read_latest, this, _1, _2));
 }
 
 deferred<std::string> elliptics_service_t::read(const std::string &collection, const std::string &key)
@@ -53,6 +54,17 @@ deferred<std::string> elliptics_service_t::read(const std::string &collection, c
 	deferred<std::string> promise;
 
 	m_elliptics->async_read(collection, key).connect(std::bind(&elliptics_service_t::on_read_completed,
+		promise, _1, _2));
+
+	return promise;
+}
+
+deferred<std::string> elliptics_service_t::read_latest(const std::string &collection, const std::string &key)
+{
+	debug() << "read_latest, collection: " << collection << ", key: " << key << std::endl;
+	deferred<std::string> promise;
+
+	m_elliptics->async_read_latest(collection, key).connect(std::bind(&elliptics_service_t::on_read_completed,
 		promise, _1, _2));
 
 	return promise;

--- a/cocaine/plugins/service.hpp
+++ b/cocaine/plugins/service.hpp
@@ -47,6 +47,7 @@ class elliptics_service_t : public api::service_t
 		deferred<std::map<std::string, std::string> > bulk_read(const std::string &collection, const std::vector<std::string> &keys);
 		deferred<std::map<std::string, int> > bulk_write(const std::string &collection, const std::vector<std::string> &keys,
 			const std::vector<std::string> &blob);
+		deferred<std::string> read_latest(const std::string &collection, const std::string &key);
 
 	private:
 		typedef storage::elliptics_storage_t::key_name_map key_name_map;

--- a/cocaine/plugins/storage.cpp
+++ b/cocaine/plugins/storage.cpp
@@ -221,6 +221,24 @@ ell::async_read_result elliptics_storage_t::async_read(const std::string &collec
 	return session.read_data(key, 0, 0);
 }
 
+ell::async_read_result elliptics_storage_t::async_read_latest(const std::string &collection, const std::string &key)
+{
+	using namespace std::placeholders;
+
+	COCAINE_LOG_DEBUG(
+		m_log,
+		"reading the '%s' object, collection: '%s'",
+		key,
+		collection
+	);
+
+	ell::session session = m_session.clone();
+	session.set_namespace(collection.data(), collection.size());
+	session.set_timeout(m_timeouts.read);
+
+	return session.read_latest(key, 0, 0);
+}
+
 static void on_adding_index_finished(const elliptics_storage_t::log_ptr &log,
 	ell::async_result_handler<ell::write_result_entry> handler,
 	const ell::error_info &err)

--- a/cocaine/plugins/storage.hpp
+++ b/cocaine/plugins/storage.hpp
@@ -79,6 +79,7 @@ class elliptics_storage_t : public api::storage_t
 		std::pair<ioremap::elliptics::async_read_result, key_name_map> async_bulk_read(const std::string &collection, const std::vector<std::string> &keys);
 		ioremap::elliptics::async_write_result async_bulk_write(const std::string &collection, const std::vector<std::string> &keys,
 			const std::vector<std::string> &blobs);
+		ioremap::elliptics::async_read_result async_read_latest(const std::string &collection, const std::string &key);
 
 		static std::vector<std::string> convert_list_result(const ioremap::elliptics::sync_find_indexes_result &result);
 


### PR DESCRIPTION
Backport of #500 from 2.26.
