### PR TITLE
Build-Deps: blackhole-dev (>= 0.2.1-1)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends:	cdbs,
 		debhelper (>= 7.0.50~),
 		eblob (>= 0.22.6),
 		react-dev (>= 2.3.1),
-		blackhole-dev (>= 0.2.0-2),
+		blackhole-dev (>= 0.2.1-1),
 		libboost-dev,
 		libboost-iostreams-dev,
 		libboost-program-options-dev,
@@ -66,7 +66,7 @@ Description: Distributed hash table storage (debug files)
 
 Package: elliptics-dev
 Architecture: any
-Depends: elliptics-client (= ${Source-Version}), blackhole-dev (>= 0.2.0-0rc2)
+Depends: elliptics-client (= ${Source-Version}), blackhole-dev (>= 0.2.1-1)
 Description: Distributed hash table storage (includes)
  Elliptics network is a fault tolerant distributed hash table object storage.
 


### PR DESCRIPTION
The reason  for this pull request is a bug fix in blackhole:
https://github.com/3Hren/blackhole/commit/e1bcb0d9868f083e396c835cbe57a3fb53f1c7b0

Blackhole is a header only library, so one has to rebuild projects which use blackhole with the latest version
