### PR TITLE
Block dependency from next major version of elliptics.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,13 +4,16 @@ include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/cmake.mk
 
 ELLIPTICS_VERSION := "$(shell dpkg-parsechangelog | sed -n -r -e 's/^Version: ([^.]+\.[^.]+\.[^.]).*/\1/p')"
+ELLIPTICS_MAJOR := $(shell echo $(ELLIPTICS_VERSION)|cut -f1 -d.)
+ELLIPTICS_NINOR := $(shell echo $(ELLIPTICS_VERSION)|cut -f2 -d.)
+ELLIPTICS_NEXT_VERSION := "$(ELLIPTICS_MAJOR).$(shell echo $$(( $(ELLIPTICS_NINOR) + 1 )) )"
 PYTHON_LIB_PATH := "$(shell python -c 'from distutils import sysconfig; print sysconfig.get_python_lib(),')"
 
 DEB_CMAKE_EXTRA_FLAGS := -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 DEB_DH_STRIP_ARGS := --dbg-package=elliptics-dbg
-DEB_DH_MAKESHLIBS_ARGS_elliptics := -V "elliptics (>= $(ELLIPTICS_VERSION))"
-DEB_DH_MAKESHLIBS_ARGS_elliptics-client := -V "elliptics-client (>= $(ELLIPTICS_VERSION))"
+DEB_DH_MAKESHLIBS_ARGS_elliptics := -V "elliptics (>= $(ELLIPTICS_VERSION)), elliptics (<< $(ELLIPTICS_NEXT_VERSION))"
+DEB_DH_MAKESHLIBS_ARGS_elliptics-client := -V "elliptics-client (>= $(ELLIPTICS_VERSION)), elliptics-client (<< $(ELLIPTICS_NEXT_VERSION))"
 DEB_COMPRESS_EXCLUDE := .conf
 DEB_MAKE_CHECK_TARGET=test
 


### PR DESCRIPTION
2.27 will be incompatible with 2.26. So, any client built with 2.26 shouldn't be
dependent from 2.27. And so on.

If it possible to backport this change to 2.25 it would be great.
