### PR TITLE
Core: do not recalculate state weight after commands without data. If @sum is 0 it could not be increased via multiplying by 10 - skip this and use first state.

### DIFF
--- a/library/dnet_common.c
+++ b/library/dnet_common.c
@@ -864,7 +864,7 @@ static int dnet_weight_get_winner(struct dnet_weight *w, int num)
 	 * This simple algorithm increases all weights until they sum up
 	 * to the large enough range.
 	 */
-	while (sum < 1000) {
+	while (sum && sum < 1000) {
 		double mult = 10.0;
 
 		sum *= mult;

--- a/library/trans.c
+++ b/library/trans.c
@@ -291,7 +291,7 @@ void dnet_trans_destroy(struct dnet_trans *t)
 			char time_str[64];
 			double old_weight = st->weight;
 
-			if (st && (t->cmd.status == 0) && !(local_io->flags & DNET_IO_FLAGS_CACHE)) {
+			if (st && (t->cmd.status == 0) && !(local_io->flags & DNET_IO_FLAGS_CACHE) && local_io->size) {
 				double norm = (double)diff / (double)local_io->size;
 
 				st->weight = 1.0 / ((1.0 / st->weight + norm) / 2.0);


### PR DESCRIPTION
Write-commit without data is good case but it resets state weight to 0. After that dnet_weight_get_winner gets sum=0 that leads to endless loop. Commands without data (null data) mustn't change the weight of a state.
Endless loop is bad too that's why we have to ends it and use first available state.
