### PR TITLE
fixed check for gcc version: support for noexcept on class constructor a...

### DIFF
--- a/include/elliptics/error.hpp
+++ b/include/elliptics/error.hpp
@@ -23,7 +23,7 @@
 
 namespace ioremap { namespace elliptics {
 
-#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ < 5
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ < 6
 /*
  * GCC-4.4 doesn't have noexcept support yet
  */


### PR DESCRIPTION
fixed check for gcc version: support for noexcept on class constructor available only since gcc 4.6( https://gcc.gnu.org/projects/cxx0x.html )

for example it's used here https://github.com/reverbrain/elliptics/blob/ebd6268aca16f808e5884121059b637f90a3a247/library/backend.h#L72
