### PR TITLE
Fixed remove_on_fail implementation

### DIFF
--- a/bindings/cpp/session.cpp
+++ b/bindings/cpp/session.cpp
@@ -473,7 +473,9 @@ void none(const error_info &, const std::vector<dnet_cmd> &)
 {
 }
 
-void remove_on_fail_impl(session &sess, const error_info &error, const std::vector<dnet_cmd> &statuses) {
+void remove_on_fail_impl(session &sess_, const error_info &error, const std::vector<dnet_cmd> &statuses) {
+	auto sess = sess_.clone();
+
 	logger &log = sess.get_logger();
 
 	if (statuses.size() == 0) {


### PR DESCRIPTION
We need to clone session to be sure that the session will be used only
in one transaction simultaneously

According to https://github.com/reverbrain/elliptics/issues/526
