### PR TITLE
recovery: fixed recovering keys which have several alive copies at one backend.

### DIFF
--- a/recovery/elliptics_recovery/dc_recovery.py
+++ b/recovery/elliptics_recovery/dc_recovery.py
@@ -108,9 +108,9 @@ class KeyRecover(object):
             else:
                 log.debug("Writing key: {0} to groups: {1}"
                           .format(repr(self.key), self.diff_groups + self.missed_groups))
-                params = {'key' : self.key,
-                          'data' : self.write_data,
-                          'remote_offset' : self.recovered_size}
+                params = {'key': self.key,
+                          'data': self.write_data,
+                          'remote_offset': self.recovered_size}
                 if self.chunked:
                     if self.recovered_size == 0:
                         params['psize'] = self.total_size
@@ -162,6 +162,9 @@ class KeyRecover(object):
             if self.recovered_size == 0:
                 self.write_session.user_flags = results[-1].user_flags
                 self.write_session.timestamp = results[-1].timestamp
+                if self.total_size != results[-1].total_size:
+                    self.total_size = results[-1].total_size
+                    self.chunked = self.total_size > self.ctx.chunk_size
             self.attempt = 0
 
             if self.chunked and len(results) > 1:

--- a/recovery/elliptics_recovery/types/merge.py
+++ b/recovery/elliptics_recovery/types/merge.py
@@ -236,6 +236,9 @@ class Recovery(object):
             if self.recovered_size == 0:
                 self.session.user_flags = results[0].user_flags
                 self.session.timestamp = results[0].timestamp
+                if self.total_size != results[0].total_size:
+                    self.total_size = results[0].total_size
+                    self.chunked = self.total_size > self.ctx.chunk_size
             self.stats.read += 1
             self.write_data = results[0].data
             self.total_size = results[0].io_attribute.total_size


### PR DESCRIPTION
Some version of eblob left several copies of one key alive. Last of them hides the rest while reading/rewriting. But iterator will return all of them. In common case it is ok because all results can be sorted by timestamp and if some key has several copies the newest (with latest timestamp) can be considered as alive and the rest as died. But it doesn't work if iterator is run with `no_meta` flag because all copies will have the same `empty` timestamp. It makes dnet_recovery with `-M/--no-meta` to recheck total_size of keys after reading first chunk.