### PR TITLE
Iterator: skip keys which extended header can't be extracted

### DIFF
--- a/tests/pytests/test_session_iterator.py
+++ b/tests/pytests/test_session_iterator.py
@@ -64,7 +64,7 @@ def check_iterator_results(node, backend, iterator, session, node_id, no_meta=Fa
 
         if no_meta:
             assert result.response.user_flags == 0
-            assert result.response.timestamp == elliptics.Time(2 ** 64 - 1, 2 ** 64 - 1)
+            assert result.response.timestamp == elliptics.Time(0, 0)
 
         # Test flow control on after result
         if counter == 0:


### PR DESCRIPTION
In our reality some records can be corrupted because of many issues. Iteration should skip such records if it is possible and continue iterating all valid records.  In this case it will safely skip records with corrupted extended header. While recovering all such keys will be recovered if at least one replica has a non-corrupted copy of these keys.