### PR TITLE
statistics: restored `backend::config` for disabled eblob and filesystem backends.

### DIFF
--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2008+ Evgeniy Polyakov <zbr@ioremap.net>
+ * Copytight 2015+ Kirill Smorodinnikov <shaitkir@gmail.com>
  *
  * This file is part of Elliptics.
  *
@@ -47,6 +48,7 @@
 
 #include "monitor/measure_points.h"
 
+#include "example/eblob_backend.h"
 /*
  * FIXME: __unused is used internally by glibc, so it may cause conflicts.
  */
@@ -65,12 +67,6 @@ trace_id_t get_trace_id()
 	return backend_trace_id_hook;
 }
 
-struct eblob_read_params {
-	int			fd;
-	int			pad;
-	uint64_t		offset;
-};
-
 static int eblob_read_params_compare(const void *p1, const void *p2)
 {
 	const struct eblob_read_params *r1 = p1;
@@ -88,19 +84,6 @@ static int eblob_read_params_compare(const void *p1, const void *p2)
 
 	return 0;
 }
-
-struct eblob_backend_config {
-	struct eblob_config		data;
-	struct eblob_backend		*eblob;
-	dnet_logger			*blog;
-	struct eblob_log		log;
-
-	pthread_mutex_t			last_read_lock;
-	int64_t				vm_total;		/* squared in bytes */
-	int				random_access;
-	int				last_read_index;
-	struct eblob_read_params	last_reads[100];
-};
 
 /* Pre-callback that formats arguments and calls ictl->callback */
 static int blob_iterate_callback_common(struct eblob_disk_control *dc, void *data, void *priv, int no_meta) {
@@ -1156,6 +1139,7 @@ static struct dnet_config_backend dnet_eblob_backend = {
 	.size			= sizeof(struct eblob_backend_config),
 	.init			= dnet_blob_config_init,
 	.cleanup		= dnet_blob_config_cleanup,
+	.to_json		= dnet_blob_config_to_json,
 };
 
 struct dnet_config_backend *dnet_eblob_backend_info(void)

--- a/example/eblob_backend.cpp
+++ b/example/eblob_backend.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copytight 2015+ Kirill Smorodinnikov <shaitkir@gmail.com>
+ *
+ * This file is part of Elliptics.
+ *
+ * Elliptics is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Elliptics is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Elliptics.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "example/eblob_backend.h"
+
+#include "elliptics/packet.h"
+#include "elliptics/backends.h"
+
+#include "rapidjson/document.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/stringbuffer.h"
+
+int dnet_blob_config_to_json(struct dnet_config_backend *b, char **json_stat, size_t *size) {
+	struct eblob_backend_config *c = static_cast<struct eblob_backend_config *>(b->data);
+	int err = 0;
+
+	rapidjson::Document doc;
+	doc.SetObject();
+	rapidjson::Document::AllocatorType &allocator = doc.GetAllocator();
+
+	doc.AddMember("blob_flags", c->data.blob_flags, allocator);
+	doc.AddMember("sync", c->data.sync, allocator);
+	doc.AddMember("data", c->data.file, allocator);
+	doc.AddMember("blob_size", c->data.blob_size, allocator);
+	doc.AddMember("records_in_blob", c->data.records_in_blob, allocator);
+	doc.AddMember("defrag_percentage", c->data.defrag_percentage, allocator);
+	doc.AddMember("defrag_timeout", c->data.defrag_timeout, allocator);
+	doc.AddMember("index_block_size", c->data.index_block_size, allocator);
+	doc.AddMember("index_block_bloom_length", c->data.index_block_bloom_length, allocator);
+	doc.AddMember("blob_size_limit", c->data.blob_size_limit, allocator);
+	doc.AddMember("defrag_time", c->data.defrag_time, allocator);
+	doc.AddMember("defrag_splay", c->data.defrag_splay, allocator);
+
+	rapidjson::StringBuffer buffer;
+	rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+	doc.Accept(writer);
+
+	std::string json = buffer.GetString();
+
+	*json_stat = (char *)malloc(json.length() + 1);
+	if (*json_stat) {
+		*size = json.length();
+		snprintf(*json_stat, *size + 1, "%s", json.c_str());
+	} else {
+		err = -ENOMEM;
+		goto err_out_reset;
+	}
+
+	return 0;
+
+err_out_reset:
+	*size = 0;
+	*json_stat = NULL;
+	return err;
+}
+

--- a/example/eblob_backend.h
+++ b/example/eblob_backend.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015+ Kirill Smorodinnikov <shaitkir@gmail.com>
+ *
+ * This file is part of Elliptics.
+ *
+ * Elliptics is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Elliptics is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Elliptics.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __DNET_EBLOB_BACKEND_H
+#define __DNET_EBLOB_BACKEND_H
+
+#include <sys/types.h>
+
+#include <eblob/blob.h>
+
+#include "elliptics/interface.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct dnet_config_backend;
+
+struct eblob_read_params {
+	int			fd;
+	int			pad;
+	uint64_t		offset;
+};
+
+struct eblob_backend_config {
+	struct eblob_config		data;
+	struct eblob_backend		*eblob;
+	dnet_logger			*blog;
+	struct eblob_log		log;
+
+	pthread_mutex_t			last_read_lock;
+	int64_t				vm_total;		/* squared in bytes */
+	int				random_access;
+	int				last_read_index;
+	struct eblob_read_params	last_reads[100];
+};
+
+int dnet_blob_config_to_json(struct dnet_config_backend *b, char **json_stat, size_t *size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __DNET_EBLOB_BACKEND_H */

--- a/example/file_backend.cpp
+++ b/example/file_backend.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copytight 2015+ Kirill Smorodinnikov <shaitkir@gmail.com>
+ *
+ * This file is part of Elliptics.
+ *
+ * Elliptics is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Elliptics is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Elliptics.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "example/file_backend.h"
+
+#include "elliptics/packet.h"
+#include "elliptics/backends.h"
+
+#include "rapidjson/document.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/stringbuffer.h"
+
+int dnet_file_config_to_json(struct dnet_config_backend *b, char **json_stat, size_t *size) {
+	struct file_backend_root *r = static_cast<struct file_backend_root *>(b->data);
+	int err = 0;
+
+	rapidjson::Document doc;
+	doc.SetObject();
+	rapidjson::Document::AllocatorType &allocator = doc.GetAllocator();
+
+	doc.AddMember("directory_bit_number", r->bit_num, allocator);
+	doc.AddMember("sync", r->sync, allocator);
+	doc.AddMember("root", r->root, allocator);
+	doc.AddMember("records_in_blob", r->records_in_blob, allocator);
+	doc.AddMember("blob_size", r->blob_size, allocator);
+	doc.AddMember("defrag_timeout", r->defrag_timeout, allocator);
+	doc.AddMember("defrag_percentage", r->defrag_percentage, allocator);
+
+	rapidjson::StringBuffer buffer;
+	rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+	doc.Accept(writer);
+
+	std::string json = buffer.GetString();
+
+	*json_stat = (char *)malloc(json.length() + 1);
+	if (*json_stat) {
+		*size = json.length();
+		snprintf(*json_stat, *size + 1, "%s", json.c_str());
+	} else {
+		err = -ENOMEM;
+		goto err_out_reset;
+	}
+
+	return 0;
+
+err_out_reset:
+	*size = 0;
+	*json_stat = NULL;
+	return err;
+}

--- a/example/file_backend.h
+++ b/example/file_backend.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015+ Kirill Smorodinnikov <shaitkir@gmail.com>
+ *
+ * This file is part of Elliptics.
+ *
+ * Elliptics is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Elliptics is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Elliptics.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __DNET_FILE_BACKEND_H
+#define __DNET_FILE_BACKEND_H
+
+#include <sys/types.h>
+#include <stdint.h>
+
+#include <eblob/blob.h>
+
+#include "elliptics/interface.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct dnet_config_backend;
+
+struct file_backend_root
+{
+	char			*root;
+	int			root_len;
+	int			sync;
+	int			bit_num;
+
+	uint64_t		records_in_blob;
+	uint64_t		blob_size;
+	int			defrag_percentage;
+	int			defrag_timeout;
+
+	dnet_logger		*blog;
+	struct eblob_log	log;
+	struct eblob_backend	*meta;
+};
+
+int dnet_file_config_to_json(struct dnet_config_backend *b, char **json_stat, size_t *size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __DNET_FILE_BACKEND_H */

--- a/include/elliptics/backends.h
+++ b/include/elliptics/backends.h
@@ -82,6 +82,7 @@ struct dnet_config_backend {
 
 	int				(* init)(struct dnet_config_backend *b);
 	void				(* cleanup)(struct dnet_config_backend *b);
+	int				(* to_json)(struct dnet_config_backend *b, char **json_stat, size_t *size);
 
 	struct dnet_backend_callbacks	cb;
 };

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -24,8 +24,10 @@ set(ELLIPTICS_SRCS
     ../example/config.hpp
     ../example/config.cpp
     ../example/config_impl.cpp
+    ../example/file_backend.cpp
     ../example/file_backend.c
     ../example/backends.c
+    ../example/eblob_backend.cpp
     ../example/eblob_backend.c
     )
 

--- a/monitor/backends_stat_provider.cpp
+++ b/monitor/backends_stat_provider.cpp
@@ -127,25 +127,54 @@ static void fill_backend_status(rapidjson::Value &stat_value,
 /*
  * This function is called to fill in config values read from the config for non-enabled (yet) backends.
  *
- * They are not parsed and can be invalid, like string instead of int and so on,
- * that's why it doesn't fill 'backend::config' section, but 'backend::config_template'.
+ * If config template provides API for serializing parsed config values to json
+ * it fills 'backend::config' section otherwise it uses unparsed values from original config
+ * and fills 'backend::config_template'
  *
- * After config has been enabled, @fill_backend_backend() is called instead.
+ * After backend has been enabled, @fill_backend_backend() is called instead.
  */
 static void fill_disabled_backend_config(rapidjson::Value &stat_value,
                                          rapidjson::Document::AllocatorType &allocator,
-					 const dnet_backend_info &config_backend) {
+                                         const dnet_backend_info &config_backend) {
 	rapidjson::Value backend_value(rapidjson::kObjectType);
-	rapidjson::Value config_value(rapidjson::kObjectType);
 
-	for (auto it = config_backend.options.begin(); it != config_backend.options.end(); ++it) {
-		const dnet_backend_config_entry &entry = *it;
+	/* If config template provides API for serializing parsed config values to json - use it */
+	if (config_backend.config_template.to_json) {
+		char *json_stat = NULL;
+		size_t size = 0;
 
-		rapidjson::Value tmp_val(entry.value_template.data(), allocator);
-		config_value.AddMember(entry.entry->key, tmp_val, allocator);
+		dnet_config_backend config = config_backend.config_template;
+		std::vector<char> data(config.size, '\0');
+		config.data = data.data();
+		config.log = config_backend.log.get();
+
+		for (auto it = config_backend.options.begin(); it != config_backend.options.end(); ++it) {
+			const dnet_backend_config_entry &entry = *it;
+
+			std::vector<char> tmp(entry.value_template.begin(), entry.value_template.end());
+			entry.entry->callback(&config, entry.entry->key, tmp.data());
+		}
+
+		config.to_json(&config, &json_stat, &size);
+		if (json_stat && size) {
+			rapidjson::Document config_value(&allocator);
+			config_value.Parse<0>(json_stat);
+			backend_value.AddMember("config",
+			                        static_cast<rapidjson::Value&>(config_value),
+			                        allocator);
+		}
+		free(json_stat);
+	} else {
+		rapidjson::Value config_value(rapidjson::kObjectType);
+		for (auto it = config_backend.options.begin(); it != config_backend.options.end(); ++it) {
+			const dnet_backend_config_entry &entry = *it;
+
+			rapidjson::Value tmp_val(entry.value_template.data(), allocator);
+			config_value.AddMember(entry.entry->key, tmp_val, allocator);
+		}
+		backend_value.AddMember("config_template", config_value, allocator);
 	}
 
-	backend_value.AddMember("config_template", config_value, allocator);
 	stat_value.AddMember("backend", backend_value, allocator);
 }
 
@@ -176,7 +205,6 @@ static rapidjson::Value& backend_stats_json(uint64_t categories,
 
 		if (categories & DNET_MONITOR_BACKEND) {
 			fill_backend_backend(stat_value, allocator, backend);
-			stat_value["backend"]["config"].AddMember("group", config_backend.group, allocator);
 		}
 		if (categories & DNET_MONITOR_IO) {
 			fill_backend_io(stat_value, allocator, backend);
@@ -186,6 +214,10 @@ static rapidjson::Value& backend_stats_json(uint64_t categories,
 		}
 	} else if (categories & DNET_MONITOR_BACKEND) {
 		fill_disabled_backend_config(stat_value, allocator, config_backend);
+	}
+
+	if (categories & DNET_MONITOR_BACKEND) {
+		stat_value["backend"]["config"].AddMember("group", config_backend.group, allocator);
 	}
 
 	return stat_value;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,8 +27,10 @@ add_library(test_common STATIC
     ../example/common.c
     ../example/config.cpp
     ../example/config_impl.cpp
+    ../example/file_backend.cpp
     ../example/file_backend.c
     ../example/backends.c
+    ../example/eblob_backend.cpp
     ../example/eblob_backend.c
     ../example/module_backend/core/module_backend_t.c
     ../example/module_backend/core/dlopen_handle_t.c


### PR DESCRIPTION
Provided `to_json` methods for eblob and filesystem config templates which serializes to json parsed config values. Made `fill_disabled_backend_config` to use `to_json` method of config template for filling `backend::config` with parsed config values if `to_json` is available, otherwise to fill `backend::config_template` with unparsed values from original config.