### PR TITLE
Fixes & optimization

### DIFF
--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -130,7 +130,6 @@ static int blob_iterate_callback_common(struct eblob_disk_control *dc, void *dat
 	err = ictl->callback(ictl->callback_private, (struct dnet_raw_id *)&dc->key,
 	                     data, size, &elist);
 
-err:
 	dnet_ext_list_destroy(&elist);
 	return err;
 }

--- a/example/eblob_backend.cpp
+++ b/example/eblob_backend.cpp
@@ -36,7 +36,10 @@ int dnet_blob_config_to_json(struct dnet_config_backend *b, char **json_stat, si
 
 	doc.AddMember("blob_flags", c->data.blob_flags, allocator);
 	doc.AddMember("sync", c->data.sync, allocator);
-	doc.AddMember("data", c->data.file, allocator);
+	if (c->data.file)
+		doc.AddMember("data", c->data.file, allocator);
+	else
+		doc.AddMember("data", "", allocator);
 	doc.AddMember("blob_size", c->data.blob_size, allocator);
 	doc.AddMember("records_in_blob", c->data.records_in_blob, allocator);
 	doc.AddMember("defrag_percentage", c->data.defrag_percentage, allocator);

--- a/indexes/local_session.cpp
+++ b/indexes/local_session.cpp
@@ -47,9 +47,6 @@ local_session::local_session(dnet_backend_io *backend, dnet_node *node) : m_back
 	if (!m_state)
 		throw std::bad_alloc();
 
-	dnet_addr addr;
-	memset(&addr, 0, sizeof(addr));
-
 	memset(m_state, 0, sizeof(dnet_net_state));
 
 	m_state->__need_exit = -1;
@@ -57,7 +54,7 @@ local_session::local_session(dnet_backend_io *backend, dnet_node *node) : m_back
 	m_state->read_s = -1;
 	m_state->accept_s = -1;
 
-	dnet_state_micro_init(m_state, node, &addr, 0);
+	dnet_state_micro_init(m_state, node, node->addrs, 0);
 	dnet_state_get(m_state);
 }
 

--- a/library/backend.h
+++ b/library/backend.h
@@ -64,6 +64,8 @@ struct dnet_backend_info
 	{
 		dnet_empty_time(&last_start);
 		last_start_err = 0;
+		memset(&config_template, 0, sizeof(config_template));
+		memset(&config, 0, sizeof(config));
 	}
 
 	dnet_backend_info(const dnet_backend_info &other) = delete;

--- a/library/dnet_common.c
+++ b/library/dnet_common.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2008+ Evgeniy Polyakov <zbr@ioremap.net>
+ * Copyright 2015+ Yandex
  *
  * This file is part of Elliptics.
  * 
@@ -620,6 +621,7 @@ int dnet_request_cmd(struct dnet_session *s, struct dnet_trans_control *ctl)
 	int num = 0;
 	struct dnet_net_state *st;
 	struct dnet_idc *idc;
+	struct rb_node *it;
 	struct dnet_group *g;
 	struct timeval start, end;
 	long diff;
@@ -627,7 +629,8 @@ int dnet_request_cmd(struct dnet_session *s, struct dnet_trans_control *ctl)
 	gettimeofday(&start, NULL);
 
 	pthread_mutex_lock(&n->state_lock);
-	list_for_each_entry(g, &n->group_list, group_entry) {
+	for (it = rb_first(&n->group_root); it; it = rb_next(it)) {
+		g = rb_entry(it, struct dnet_group, group_entry);
 		list_for_each_entry(idc, &g->idc_list, group_entry) {
 			st = idc->st;
 			if (st == n->st)

--- a/library/dnet_common.c
+++ b/library/dnet_common.c
@@ -1,6 +1,5 @@
 /*
  * Copyright 2008+ Evgeniy Polyakov <zbr@ioremap.net>
- * Copyright 2015+ Yandex
  *
  * This file is part of Elliptics.
  * 

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2008+ Evgeniy Polyakov <zbr@ioremap.net>
+ * Copyright 2015+ Yandex
  *
  * This file is part of Elliptics.
  *
@@ -360,9 +361,10 @@ void dnet_notify_exit(struct dnet_node *n);
 
 struct dnet_group
 {
-	struct list_head	group_entry;
+	struct rb_node		group_entry;
 
 	unsigned int		group_id;
+	struct dnet_node	*node;
 
 	struct list_head	idc_list;
 
@@ -567,7 +569,7 @@ struct dnet_node
 	struct dnet_addr	*addrs;
 
 	pthread_mutex_t		state_lock;
-	struct list_head	group_list;
+	struct rb_root		group_root;
 
 	/* hosts client states, i.e. those who didn't join network */
 	struct list_head	empty_state_list;

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -1,6 +1,5 @@
 /*
  * Copyright 2008+ Evgeniy Polyakov <zbr@ioremap.net>
- * Copyright 2015+ Yandex
  *
  * This file is part of Elliptics.
  *

--- a/library/net.cpp
+++ b/library/net.cpp
@@ -826,6 +826,21 @@ static void dnet_process_socket(dnet_connect_state &state, epoll_event &ev)
 		dnet_addr_container *cnt = reinterpret_cast<dnet_addr_container *>(socket->buffer);
 		int err;
 
+		/* If we are server check that connected node has the same number of addresses.
+		 * At the moment server nodes with different number of addresses can't be connected to each other.
+		 */
+		if (state.node->addr_num && (cnt->addr_num != state.node->addr_num)) {
+			err = -EINVAL;
+			dnet_log(state.node, DNET_LOG_ERROR, "%s: received dnet_addr_container "
+				"is invalid, recv-addr-num: %d, local-addr-num: %d, err: %d",
+				dnet_addr_string(&socket->addr),
+				int(cnt->addr_num),
+				state.node->addr_num,
+				err);
+			dnet_fail_socket(state, socket, err);
+			break;
+		}
+
 		if (cmd->size < sizeof(dnet_addr_container) + cnt->addr_num * sizeof(dnet_addr) + sizeof(dnet_id_container)) {
 			err = -EINVAL;
 			dnet_log(state.node, DNET_LOG_ERROR, "%s: received dnet_addr_container "

--- a/library/net.cpp
+++ b/library/net.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2008+ Evgeniy Polyakov <zbr@ioremap.net>
  * Copyright 2014+ Ruslan Nigmatullin <euroelessar@yandex.ru>
+ * Copyright 2015+ Yandex
  *
  * This file is part of Elliptics.
  *
@@ -1197,8 +1198,10 @@ static net_state_list_ptr dnet_check_route_table_victims(struct dnet_node *node,
 	size_t groups_count = 0;
 	pthread_mutex_lock(&node->state_lock);
 
+	struct rb_node *it;
 	struct dnet_group *g;
-	list_for_each_entry(g, &node->group_list, group_entry) {
+	for (it = rb_first(&node->group_root); it; it = rb_next(it)) {
+		g = rb_entry(it, struct dnet_group, group_entry);
 		groups[groups_count++] = g->group_id;
 
 		if (groups_count >= groups_count_limit)

--- a/library/net.cpp
+++ b/library/net.cpp
@@ -1,7 +1,6 @@
 /*
  * Copyright 2008+ Evgeniy Polyakov <zbr@ioremap.net>
  * Copyright 2014+ Ruslan Nigmatullin <euroelessar@yandex.ru>
- * Copyright 2015+ Yandex
  *
  * This file is part of Elliptics.
  *

--- a/library/node.c
+++ b/library/node.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2008+ Evgeniy Polyakov <zbr@ioremap.net>
+ * Copyright 2015+ Yandex
  *
  * This file is part of Elliptics.
  * 
@@ -80,7 +81,7 @@ static struct dnet_node *dnet_node_alloc(struct dnet_config *cfg)
 	}
 	pthread_attr_setdetachstate(&n->attr, PTHREAD_CREATE_DETACHED);
 
-	INIT_LIST_HEAD(&n->group_list);
+	n->group_root = RB_ROOT;
 	INIT_LIST_HEAD(&n->empty_state_list);
 	INIT_LIST_HEAD(&n->dht_state_list);
 	INIT_LIST_HEAD(&n->storage_state_list);
@@ -106,7 +107,7 @@ err_out_free:
 	return NULL;
 }
 
-static struct dnet_group *dnet_group_create(unsigned int group_id)
+static struct dnet_group *dnet_group_create(struct dnet_node *n, unsigned int group_id)
 {
 	struct dnet_group *g;
 
@@ -118,6 +119,7 @@ static struct dnet_group *dnet_group_create(unsigned int group_id)
 
 	atomic_init(&g->refcnt, 1);
 	g->group_id = group_id;
+	g->node = n;
 
 	INIT_LIST_HEAD(&g->idc_list);
 
@@ -133,23 +135,54 @@ void dnet_group_destroy(struct dnet_group *g)
 		fprintf(stderr, "BUG in dnet_group_destroy, reference leak.");
 		exit(-1);
 	}
-	list_del(&g->group_entry);
+	rb_erase(&g->group_entry, &g->node->group_root);
 	free(g->ids);
 	free(g);
 }
 
 static struct dnet_group *dnet_group_search(struct dnet_node *n, unsigned int group_id)
 {
-	struct dnet_group *g, *found = NULL;
+	struct rb_root *root = &n->group_root;
+	struct rb_node *it = root->rb_node;
+	struct dnet_group *g = NULL;
 
-	list_for_each_entry(g, &n->group_list, group_entry) {
-		if (g->group_id == group_id) {
-			found = dnet_group_get(g);
-			break;
-		}
+	while (it) {
+		g = rb_entry(it, struct dnet_group, group_entry);
+
+		if (g->group_id < group_id)
+			it = it->rb_left;
+		else if (g->group_id > group_id)
+			it = it->rb_right;
+		else
+			return dnet_group_get(g);
 	}
 
-	return found;
+	return NULL;
+}
+
+int dnet_group_insert_nolock(struct dnet_node *n, struct dnet_group *a)
+{
+	struct rb_root *root = &n->group_root;
+	struct rb_node **it = &root->rb_node, *parent = NULL;
+	struct dnet_group *g = NULL;
+
+	while (*it) {
+		parent = *it;
+
+		g = rb_entry(parent, struct dnet_group, group_entry);
+
+		if (g->group_id < a->group_id)
+			it = &parent->rb_left;
+		else if (g->group_id > a->group_id)
+			it = &parent->rb_right;
+		else
+			return -EEXIST;
+	}
+
+	rb_link_node(&a->group_entry, parent, it);
+	rb_insert_color(&a->group_entry, root);
+
+	return 0;
 }
 
 static int dnet_idc_compare(const void *k1, const void *k2)
@@ -276,11 +309,13 @@ int dnet_idc_update_backend(struct dnet_net_state *st, struct dnet_backend_ids *
 
 	g = dnet_group_search(n, group_id);
 	if (!g) {
-		g = dnet_group_create(group_id);
+		g = dnet_group_create(n, group_id);
 		if (!g)
 			goto err_out_unlock;
 
-		list_add_tail(&g->group_entry, &n->group_list);
+		err = dnet_group_insert_nolock(n, g);
+		if (err)
+			goto err_out_unlock;
 	}
 
 	dnet_idc_remove_backend_nolock(st, backend->backend_id);

--- a/library/node.c
+++ b/library/node.c
@@ -1,6 +1,5 @@
 /*
  * Copyright 2008+ Evgeniy Polyakov <zbr@ioremap.net>
- * Copyright 2015+ Yandex
  *
  * This file is part of Elliptics.
  * 


### PR DESCRIPTION
Fixed crash upon generating statistics for disabled at startup backends - parse disabled backends config.

Use first local address of node instead of empty at local_session - fixed "invalid address" in logs.

Connection between servers with different number of address is not allowed at the moment. Added corresponding check to dnet_process_socket to prevent appearing for short time node with different number of addresses in dht_state_list. This short time appearance leads to crash if someone's route list request is handled at the same time.

Optimized operations with groups list: underlying structure is replaced by rbtree.