### PR TITLE
Python: minor changes and cleanups

### DIFF
--- a/bindings/python/elliptics_python.cpp
+++ b/bindings/python/elliptics_python.cpp
@@ -39,22 +39,22 @@ namespace bp = boost::python;
 
 namespace ioremap { namespace elliptics { namespace python {
 enum elliptics_iterator_types {
-	itype_disk = DNET_ITYPE_DISK,
-	itype_network = DNET_ITYPE_NETWORK,
+	itype_disk	= DNET_ITYPE_DISK,
+	itype_network	= DNET_ITYPE_NETWORK,
 };
 
 enum elliptics_iterator_flags {
-	iflag_default = 0,
-	iflag_data = DNET_IFLAGS_DATA,
-	iflag_key_range = DNET_IFLAGS_KEY_RANGE,
-	iflag_ts_range = DNET_IFLAGS_TS_RANGE,
-	iflag_no_meta = DNET_IFLAGS_NO_META,
+	iflag_default	= 0,
+	iflag_data	= DNET_IFLAGS_DATA,
+	iflag_key_range	= DNET_IFLAGS_KEY_RANGE,
+	iflag_ts_range	= DNET_IFLAGS_TS_RANGE,
+	iflag_no_meta	= DNET_IFLAGS_NO_META,
 };
 
 enum elliptics_cflags {
-	cflags_default = 0,
-	cflags_direct = DNET_FLAGS_DIRECT,
-	cflags_nolock = DNET_FLAGS_NOLOCK,
+	cflags_default	= 0,
+	cflags_direct	= DNET_FLAGS_DIRECT,
+	cflags_nolock	= DNET_FLAGS_NOLOCK,
 };
 
 enum elliptics_ioflags {
@@ -74,11 +74,11 @@ enum elliptics_exceptions_policy {
 	policy_no_exceptions			= ioremap::elliptics::session::no_exceptions,
 	policy_throw_at_start			= ioremap::elliptics::session::throw_at_start,
 	policy_throw_at_wait			= ioremap::elliptics::session::throw_at_wait,
-	policy_throw_at_get				= ioremap::elliptics::session::throw_at_get,
-	policy_throw_at_iterator_end	= ioremap::elliptics::session::throw_at_iterator_end,
+	policy_throw_at_get			= ioremap::elliptics::session::throw_at_get,
+	policy_throw_at_iterator_end		= ioremap::elliptics::session::throw_at_iterator_end,
 	policy_default_exceptions		= ioremap::elliptics::session::throw_at_wait |
-									  ioremap::elliptics::session::throw_at_get |
-									  ioremap::elliptics::session::throw_at_iterator_end
+						  ioremap::elliptics::session::throw_at_get |
+						  ioremap::elliptics::session::throw_at_iterator_end
 };
 
 enum elliptics_config_flags {
@@ -86,7 +86,7 @@ enum elliptics_config_flags {
 	config_flags_no_route_list		= DNET_CFG_NO_ROUTE_LIST,
 	config_flags_mix_states			= DNET_CFG_MIX_STATES,
 	config_flags_no_csum			= DNET_CFG_NO_CSUM,
-	config_flags_randomize_states	= DNET_CFG_RANDOMIZE_STATES,
+	config_flags_randomize_states		= DNET_CFG_RANDOMIZE_STATES,
 };
 
 enum elliptics_node_status_flags {

--- a/bindings/python/result_entry.cpp
+++ b/bindings/python/result_entry.cpp
@@ -60,39 +60,16 @@ std::string iterator_result_response_data(iterator_result_entry result)
 	return result.reply_data().to_string();
 }
 
-elliptics_id iterator_response_get_key(dnet_iterator_response *response)
-{
+static elliptics_id iterator_response_get_key(dnet_iterator_response *response) {
 	return elliptics_id(response->key);
 }
 
-elliptics_time iterator_response_get_timestamp(dnet_iterator_response *response)
-{
+static elliptics_time iterator_response_get_timestamp(dnet_iterator_response *response) {
 	return elliptics_time(response->timestamp);
 }
 
-uint64_t iterator_response_get_user_flags(dnet_iterator_response *response)
-{
-	return response->user_flags;
-}
-
-uint64_t iterator_response_get_size(dnet_iterator_response *response)
-{
+static uint64_t iterator_response_get_size(dnet_iterator_response *response) {
 	return response->size;
-}
-
-uint64_t iterator_response_get_total_keys(dnet_iterator_response *response)
-{
-	return response->total_keys;
-}
-
-uint64_t iterator_response_get_iterated_keys(dnet_iterator_response *response)
-{
-	return response->iterated_keys;
-}
-
-int iterator_response_get_status(dnet_iterator_response *response)
-{
-	return response->status;
 }
 
 std::string read_result_get_data(read_result_entry &result)
@@ -343,15 +320,15 @@ void init_result_entry() {
 		              "elliptics.Id of iterated key")
 		.add_property("timestamp", iterator_response_get_timestamp,
 		              "elliptics.Time timestamp of iterated key")
-		.add_property("user_flags", iterator_response_get_user_flags,
+		.add_property("user_flags", &dnet_iterator_response::user_flags,
 		              "Custom user-defined flags of iterated key")
-		.add_property("size", iterator_response_get_size,
+		.add_property("size", &dnet_iterator_response::size,
 		              "Size of iterated key data")
-		.add_property("total_keys", iterator_response_get_total_keys,
+		.add_property("total_keys", &dnet_iterator_response::total_keys,
 		              "Number of all keys")
-		.add_property("iterated_keys", iterator_response_get_iterated_keys,
+		.add_property("iterated_keys", &dnet_iterator_response::iterated_keys,
 		              "Number of iterated keys")
-		.add_property("status", iterator_response_get_status,
+		.add_property("status", &dnet_iterator_response::status,
 		              "Status of iterated key:\n"
 		              "0 - common key\n"
 		              "1 - keepalive response")

--- a/bindings/python/src/id.py
+++ b/bindings/python/src/id.py
@@ -31,7 +31,7 @@ def convert_to_list(key):
 class Id(Id):
     def __init__(self, key, group=0):
         import types
-        if type(key) is str:
+        if isinstance(key, basestring):
             super(Id, self).__init__(convert_to_list(int(key, 16)), group)
         elif type(key) in (long, int):
             super(Id, self).__init__(convert_to_list(key), group)

--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -419,7 +419,9 @@ struct eblob_read_range_priv {
 
 static int blob_cmp_range_request(const void *req1, const void *req2)
 {
-	return memcmp(((struct eblob_range_request *)(req1))->record_key, ((struct eblob_range_request *)(req2))->record_key, EBLOB_ID_SIZE);
+	return memcmp(((struct eblob_range_request *)(req1))->record_key,
+	              ((struct eblob_range_request *)(req2))->record_key,
+	              EBLOB_ID_SIZE);
 }
 
 static int blob_read_range_callback(struct eblob_range_request *req)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -33,8 +33,8 @@ set(ELLIPTICS_SRCS
 
 if (HAVE_MODULE_BACKEND_SUPPORT)
     list(APPEND ELLIPTICS_SRCS
-	../example/module_backend/core/module_backend_t.c
-	../example/module_backend/core/dlopen_handle_t.c)
+        ../example/module_backend/core/module_backend_t.c
+        ../example/module_backend/core/dlopen_handle_t.c)
 
     list(APPEND ELLIPTICS_LIBRARIES dl)
 endif()


### PR DESCRIPTION
 * Fixed indents in code.
 * removed useless getters
 * allow to use all `basestring` for `elliptics.Id` initialization not only `str`
