### PR TITLE
Added DNET_RECORD_FLAGS_UNCOMMITTED

### DIFF
--- a/bindings/python/elliptics_python.cpp
+++ b/bindings/python/elliptics_python.cpp
@@ -71,7 +71,11 @@ enum elliptics_ioflags {
 };
 
 enum elliptics_record_flags {
-	record_flags_uncommitted	= DNET_RECORD_FLAGS_UNCOMMITTED
+	record_flags_remove		= DNET_RECORD_FLAGS_REMOVE,
+	record_flags_nocsum		= DNET_RECORD_FLAGS_NOCSUM,
+	record_flags_append		= DNET_RECORD_FLAGS_APPEND,
+	record_flags_exthdr		= DNET_RECORD_FLAGS_EXTHDR,
+	record_flags_uncommitted	= DNET_RECORD_FLAGS_UNCOMMITTED,
 };
 
 enum elliptics_exceptions_policy {
@@ -430,7 +434,15 @@ BOOST_PYTHON_MODULE(core)
 
 	bp::enum_<elliptics_record_flags>("record_flags",
 		"Bit flags which specifies state of the record at the backend\n\n"
+		"remove\n    The record is removed\n"
+		"nocsum\n    The record is written without csum\n"
+		"append\n    The record is written via append\n"
+		"exthdr\n    The record is written with extended header"
 		"uncommitted\n    The record is uncommitted so it can't be read but can be writted and committed")
+		.value("remove", record_flags_remove)
+		.value("nocsum", record_flags_nocsum)
+		.value("append", record_flags_append)
+		.value("exthdr", record_flags_exthdr)
 		.value("uncommitted", record_flags_uncommitted)
 	;
 

--- a/bindings/python/elliptics_python.cpp
+++ b/bindings/python/elliptics_python.cpp
@@ -58,16 +58,20 @@ enum elliptics_cflags {
 };
 
 enum elliptics_ioflags {
-	ioflags_default = 0,
-	ioflags_append = DNET_IO_FLAGS_APPEND,
-	ioflags_prepare = DNET_IO_FLAGS_PREPARE,
-	ioflags_commit = DNET_IO_FLAGS_COMMIT,
-	ioflags_overwrite = DNET_IO_FLAGS_OVERWRITE,
-	ioflags_nocsum = DNET_IO_FLAGS_NOCSUM,
-	ioflags_plain_write = DNET_IO_FLAGS_PLAIN_WRITE,
-	ioflags_cache = DNET_IO_FLAGS_CACHE,
-	ioflags_cache_only = DNET_IO_FLAGS_CACHE_ONLY,
-	ioflags_cache_remove_from_disk = DNET_IO_FLAGS_CACHE_REMOVE_FROM_DISK,
+	ioflags_default			= 0,
+	ioflags_append			= DNET_IO_FLAGS_APPEND,
+	ioflags_prepare			= DNET_IO_FLAGS_PREPARE,
+	ioflags_commit			= DNET_IO_FLAGS_COMMIT,
+	ioflags_overwrite		= DNET_IO_FLAGS_OVERWRITE,
+	ioflags_nocsum			= DNET_IO_FLAGS_NOCSUM,
+	ioflags_plain_write		= DNET_IO_FLAGS_PLAIN_WRITE,
+	ioflags_cache			= DNET_IO_FLAGS_CACHE,
+	ioflags_cache_only		= DNET_IO_FLAGS_CACHE_ONLY,
+	ioflags_cache_remove_from_disk	= DNET_IO_FLAGS_CACHE_REMOVE_FROM_DISK,
+};
+
+enum elliptics_record_flags {
+	record_flags_uncommitted	= DNET_RECORD_FLAGS_UNCOMMITTED
 };
 
 enum elliptics_exceptions_policy {
@@ -422,6 +426,12 @@ BOOST_PYTHON_MODULE(core)
 		.value("cache", ioflags_cache)
 		.value("cache_only", ioflags_cache_only)
 		.value("cache_remove_from_disk", ioflags_cache_remove_from_disk)
+	;
+
+	bp::enum_<elliptics_record_flags>("record_flags",
+		"Bit flags which specifies state of the record at the backend\n\n"
+		"uncommitted\n    The record is uncommitted so it can't be read but can be writted and committed")
+		.value("uncommitted", record_flags_uncommitted)
 	;
 
 	bp::enum_<blackhole::defaults::severity>("log_level",

--- a/bindings/python/result_entry.cpp
+++ b/bindings/python/result_entry.cpp
@@ -332,6 +332,8 @@ void init_result_entry() {
 		              "Status of iterated key:\n"
 		              "0 - common key\n"
 		              "1 - keepalive response")
+		.add_property("flags", &dnet_iterator_response::flags,
+		              "Backend's flags of the record")
 	;
 
 	bp::class_<read_result_entry, bp::bases<callback_result_entry> >("ReadResultEntry")

--- a/bindings/python/src/__init__.py
+++ b/bindings/python/src/__init__.py
@@ -16,7 +16,7 @@
 from __future__ import absolute_import
 
 from elliptics.core import ErrorInfo, Logger, iterator_flags, monitor_stat_categories
-from elliptics.core import iterator_types, command_flags, io_flags, log_level
+from elliptics.core import iterator_types, command_flags, io_flags, log_level, record_flags
 from elliptics.core import exceptions_policy, config_flags, IteratorResultContainer
 from elliptics.core import Time, IoAttr, status_flags, Range, IteratorRange
 from elliptics.core import Error, NotFoundError, TimeoutError, filters, checkers

--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -85,13 +85,6 @@ static int eblob_read_params_compare(const void *p1, const void *p2)
 	return 0;
 }
 
-static uint64_t eblob_convert_dctl_flags(uint64_t dctl_flags) {
-	uint64_t ret = 0;
-	if (dctl_flags & BLOB_DISK_CTL_UNCOMMITTED)
-		ret |= DNET_RECORD_FLAGS_UNCOMMITTED;
-	return ret;
-}
-
 /* Pre-callback that formats arguments and calls ictl->callback */
 static int blob_iterate_callback_common(struct eblob_disk_control *dc, int fd, uint64_t data_offset, void *priv, int no_meta) {
 	struct dnet_iterator_ctl *ictl = priv;
@@ -133,7 +126,7 @@ static int blob_iterate_callback_common(struct eblob_disk_control *dc, int fd, u
 	}
 
 	err = ictl->callback(ictl->callback_private,
-	                     (struct dnet_raw_id *)&dc->key, eblob_convert_dctl_flags(dc->flags),
+	                     (struct dnet_raw_id *)&dc->key, dc->flags,
 	                     fd, data_offset, size, &elist);
 
 	dnet_ext_list_destroy(&elist);

--- a/include/elliptics/interface.h
+++ b/include/elliptics/interface.h
@@ -200,7 +200,7 @@ static inline const char *dnet_flags_dump_cfgflags(uint64_t flags)
 struct dnet_iterator_ctl {
 	void				*iterate_private;
 	void				*callback_private;
-	int				(* callback)(void *priv, struct dnet_raw_id *key,
+	int				(* callback)(void *priv, struct dnet_raw_id *key, uint64_t flags,
 			int fd, uint64_t data_offset, uint64_t dsize, struct dnet_ext_list *elist);
 };
 

--- a/include/elliptics/packet.h
+++ b/include/elliptics/packet.h
@@ -1009,8 +1009,21 @@ static inline void dnet_convert_iterator_request(struct dnet_iterator_request *r
 }
 
 
-/* Common record flags */
-#define DNET_RECORD_FLAGS_UNCOMMITTED	(1<<0) /* The record was prepared but hasn't been committed */
+/* eblob record flags */
+#define DNET_RECORD_FLAGS_REMOVE		(1<<0)
+#define DNET_RECORD_FLAGS_NOCSUM		(1<<1)
+#define DNET_RECORD_FLAGS_APPEND		(1<<4)
+/*
+ * This flag is set for records that are written in so-called extended format -
+ * records that have additional header before data - it's somewhat obscure and
+ * changes blob behaviour in various ways. Only user of this flag is elliptics.
+ */
+#define DNET_RECORD_FLAGS_EXTHDR		(1<<6)
+/*
+ * This flag is set for records that were prepared but haven't been commmitted yet.
+ * Such records doesn't available for read but can be committed even after restart.
+ */
+#define DNET_RECORD_FLAGS_UNCOMMITTED		(1<<7)
 
 /*
  * Iterator response

--- a/include/elliptics/packet.h
+++ b/include/elliptics/packet.h
@@ -1008,6 +1008,10 @@ static inline void dnet_convert_iterator_request(struct dnet_iterator_request *r
 	dnet_convert_time(&r->time_end);
 }
 
+
+/* Common record flags */
+#define DNET_RECORD_FLAGS_UNCOMMITTED	(1<<0) /* The record was prepared but hasn't been committed */
+
 /*
  * Iterator response
  * TODO: Maybe it's better to include whole ehdr in response
@@ -1019,10 +1023,11 @@ struct dnet_iterator_response
 	int				status;		/* Response status */
 	struct dnet_time		timestamp;	/* Timestamp from extended header */
 	uint64_t			user_flags;	/* User flags set in extended header */
-	uint64_t			size;
-	uint64_t			iterated_keys;
-	uint64_t			total_keys;
-	uint64_t			reserved[2];
+	uint64_t			size;		/* Size of the record */
+	uint64_t			iterated_keys;	/* Number of keys that has been iterated */
+	uint64_t			total_keys;	/* Total number of keys that will be iterated */
+	uint64_t			flags;		/* Combination of DNET_RECORD_FLAGS_* */
+	uint64_t			reserved[1];
 } __attribute__ ((packed));
 
 static inline void dnet_convert_iterator_response(struct dnet_iterator_response *r)
@@ -1033,6 +1038,7 @@ static inline void dnet_convert_iterator_response(struct dnet_iterator_response 
 	r->size = dnet_bswap64(r->size);
 	r->iterated_keys = dnet_bswap64(r->iterated_keys);
 	r->total_keys = dnet_bswap64(r->total_keys);
+	r->flags = dnet_bswap64(r->flags);
 	dnet_convert_time(&r->timestamp);
 }
 

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -423,8 +423,8 @@ static int dnet_iterator_flow_control(struct dnet_iterator_common_private *ipriv
  * Also now it "prepares" data for next callback by combining data itself with
  * fixed-size response header.
  */
-static int dnet_iterator_callback_common(void *priv, struct dnet_raw_id *key,
-					 int fd, uint64_t data_offset, uint64_t dsize, struct dnet_ext_list *elist)
+static int dnet_iterator_callback_common(void *priv, struct dnet_raw_id *key, uint64_t flags,
+                                         int fd, uint64_t data_offset, uint64_t dsize, struct dnet_ext_list *elist)
 {
 	struct dnet_iterator_common_private *ipriv = priv;
 	struct dnet_iterator_response *response;
@@ -474,6 +474,7 @@ static int dnet_iterator_callback_common(void *priv, struct dnet_raw_id *key,
 	response->size = fsize;
 	response->total_keys = ipriv->total_keys;
 	response->iterated_keys = iterated_keys;
+	response->flags = flags;
 	dnet_convert_iterator_response(response);
 
 	/* Data */

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -636,7 +636,7 @@ static int dnet_iterator_start(struct dnet_backend_io *backend, struct dnet_net_
 	/* Check callback type */
 	if (ireq->itype <= DNET_ITYPE_FIRST || ireq->itype >= DNET_ITYPE_LAST) {
 		err = -ENOTSUP;
-		dnet_log(st->n, DNET_LOG_ERROR, "%s: iteration failed: unknown iteration type: %" PRIu64,
+		dnet_log(st->n, DNET_LOG_ERROR, "%s: iteration failed: unknown iteration type: %" PRIu32,
 		         dnet_dump_id(&cmd->id), ireq->itype);
 		goto err_out_exit;
 	}
@@ -674,7 +674,7 @@ static int dnet_iterator_start(struct dnet_backend_io *backend, struct dnet_net_
 		goto err_out_exit;
 	default:
 		err = -EINVAL;
-		dnet_log(st->n, DNET_LOG_ERROR, "%s: iteration failed: unknown iteration type: %" PRIu64,
+		dnet_log(st->n, DNET_LOG_ERROR, "%s: iteration failed: unknown iteration type: %" PRIu32,
 		         dnet_dump_id(&cmd->id), ireq->itype);
 		goto err_out_exit;
 	}

--- a/recovery/elliptics_recovery/dc_recovery.py
+++ b/recovery/elliptics_recovery/dc_recovery.py
@@ -18,6 +18,7 @@ import logging
 import threading
 import os
 import traceback
+import errno
 
 from elliptics_recovery.utils.misc import elliptics_create_node, RecoverStat, validate_index, INDEX_MAGIC_NUMBER_LENGTH
 from elliptics_recovery.utils.misc import load_key_data
@@ -43,6 +44,8 @@ class KeyRecover(object):
         self.read_session.set_filter(elliptics.filters.all)
         self.write_session = elliptics.Session(node)
         self.write_session.set_checker(elliptics.checkers.all)
+        self.remove_session = elliptics.Session(node)
+        self.remove_session.set_checker(elliptics.checkers.all)
         self.result = False
         self.attempt = 0
 
@@ -55,13 +58,46 @@ class KeyRecover(object):
         self.chunked = self.total_size > self.ctx.chunk_size
         self.recovered_size = 0
 
-        def same_meta(lhs, rhs):
-            return (lhs.timestamp, lhs.size) == (rhs.timestamp, rhs.size)
+        same_ts = lambda lhs, rhs: lhs.timestamp == rhs.timestamp
+        same_infos = [info for info in self.key_infos if same_ts(info, self.key_infos[0])]
 
-        self.same_groups = [k.group_id for k in self.key_infos if same_meta(k, self.key_infos[0])]
-        self.key_infos = [k for k in self.key_infos if k.group_id not in self.same_groups]
-        self.diff_groups += [k.group_id for k in self.key_infos]
+        same_uncommitted = [info for info in same_infos if info.flags & elliptics.record_flags.uncommitted]
+        if same_uncommitted == same_infos:
+            # if all such keys have exceeded prepare timeout - remove all replicas
+            # else skip recovering because the key is under writting and can be committed in nearest future.
+            same_groups = [info.group_id for info in same_infos]
+            if same_infos[0].timestamp < self.ctx.prepare_timeout:
+                self.remove_session.groups = [info.group_id for info in self.key_infos]
+                log.info('Key: {0} replicas with newest timestamp: {1} from groups: {2} are uncommitted. '
+                         'Prepare timeout: {3} was exceeded. Remove all replicas from groups: {4}'
+                         .format(self.key, same_infos[0].timestamp, same_groups, self.ctx.prepare_timeout,
+                                 self.remove_session.groups))
+                self.remove()
+            else:
+                log.info('Key: {0} replicas with newest timestamp: {1} from groups: {2} are uncommitted. '
+                         'Prepare timeout: {3} was not exceeded. The key is written now. Skip it.'
+                         .format(self.key, same_infos[0].timestamp, same_groups, self.ctx.prepare_timeout))
+                self.stats.skipped += 1
+                self.stop(True)
+            return
+        elif same_uncommitted != []:
+            # removed incomplete replicas meta from same_infos
+            # they will be corresponding as different and will be overwritten
+            same_infos = [info for info in same_infos if info not in same_uncommitted]
+            incomplete_groups = [info.group_id for info in same_uncommitted]
+            same_groups = [info.group_id for info in same_infos]
+            log.info('Key: {0} has uncommitted replicas in groups: {1} and completed replicas in groups: {2}.'
+                     'The key will be recovered at groups with uncommitted replicas too.'
+                     .format(self.key, incomplete_groups, same_groups))
+
+        same_meta = lambda lhs, rhs: (lhs.timestamp, lhs.size) == (rhs.timestamp, rhs.size)
+        same_infos = [info for info in self.key_infos if same_meta(info, same_infos[0])]
+
+        self.same_groups = [info.group_id for info in same_infos]
+        self.key_infos = [info for info in self.key_infos if info.group_id not in self.same_groups]
+        self.diff_groups += [info.group_id for info in self.key_infos]
         self.diff_groups = list(set(self.diff_groups).difference(self.same_groups))
+
         if not self.diff_groups and not self.missed_groups:
             log.debug("Key: {0} already up-to-date in all groups: {1}".format(self.key, self.same_groups))
             self.stop(False)
@@ -81,8 +117,8 @@ class KeyRecover(object):
         self.complete.set()
 
     def read(self):
-        size = 0
         try:
+            size = self.total_size
             log.debug("Reading key: {0} from groups: {1}, chunked: {2}"
                       .format(self.key, self.read_session.groups, self.chunked))
             if self.chunked:
@@ -148,31 +184,65 @@ class KeyRecover(object):
                       .format(self.key, repr(e), traceback.format_exc()))
             self.stop(False)
 
+    def remove(self):
+        if self.ctx.safe or self.ctx.dry_run:
+            if self.ctx.safe:
+                log.info("Safe mode is turned on. Skip removing key: {0}".format(repr(self.key)))
+            else:
+                log.info("Dry-run mode is turned on. Skip removing key: {0}.".format(repr(self.key)))
+            self.stop(True)
+        else:
+            try:
+                log.info("Removing key: {0} from group: {1}".format(self.key, self.remove_session.groups))
+                remove_result = self.remove_session.remove(self.key)
+                remove_result.connect(self.onremove)
+            except:
+                log.exception("Failed to remove key: {0} from groups: {1}".format(self.key, self.remove_session.groups))
+                self.stop(False)
+
     def onread(self, results, error):
         try:
             if error.code:
                 log.error("Failed to read key: {0} from groups: {1}: {2}".format(self.key, self.same_groups, error))
-                self.stats.read_failed += 1
-                if error.code == 110 and self.attempt < self.ctx.attempts:
-                    self.attempt += len(self.read_session.groups)
-                    log.debug("Read has been timed out. Try to reread key: {0} from groups: {1}, attempt: {2}/{3}"
-                              .format(self.key, self.same_groups, self.attempt, self.ctx.attempts))
-                    self.read()
+                self.stats.read_failed += len(results)
+                if error.code == errno.ETIMEDOUT:
+                    if self.attempt < self.ctx.attempts:
+                        self.attempt += 1
+                        old_timeout = self.read_session.timeout
+                        self.read_session.timeout *= 2
+                        log.error("Read has been timed out. Try to reread key: {0} from groups: {1}, attempt: {2}/{3} "
+                                  "with increased timeout: {4}/{5}"
+                                  .format(self.key, self.same_groups, self.attempt, self.ctx.attempts,
+                                          self.read_session.timeout, old_timeout))
+                        self.read()
+                    else:
+                        log.error("Read has been timed out {0} times, all {1} attemps are used. "
+                                  "The key: {1} can't be recovery now. Skip it"
+                                  .format(self.attempt, self.key))
+                        self.stats.skipped += 1
+                        self.stop(False)
                 elif len(self.key_infos) > 1:
-                    self.stats.read_failed += len(self.read_session.groups)
+                    log.error("Key: {0} has available replicas in other groups. Try to recover the key from them"
+                              .format(self.key))
                     self.diff_groups += self.read_session.groups
                     self.run()
                 else:
-                    log.error("Failed to read key: {0} from any available group. This key couldn't be recovered now.".format(self.key))
+                    log.error("Failed to read key: {0} from any available group. "
+                              "This key can't be recovered now. Skip it"
+                              .format(self.key))
+                    self.stats.skipped += 1
                     self.stop(False)
                 return
 
+            self.stats.read_failed += len(results) - 1
             self.stats.read += 1
             self.stats.read_bytes += results[-1].size
 
             if self.recovered_size == 0:
                 self.write_session.user_flags = results[-1].user_flags
                 self.write_session.timestamp = results[-1].timestamp
+                self.read_session.ioflags |= elliptics.io_flags.nocsum
+                self.read_session.groups = [results[-1].group_id]
                 if self.total_size != results[-1].total_size:
                     self.total_size = results[-1].total_size
                     self.chunked = self.total_size > self.ctx.chunk_size
@@ -205,16 +275,12 @@ class KeyRecover(object):
                     old_timeout = self.write_session.timeout
                     self.write_session.timeout *= 2
                     self.attempt += 1
-                    log.debug("Retry to write key: {0} attempts: {1}/{2} "
-                              "increased timeout: {3}/{4}"
-                              .format(repr(self.key),
-                                      self.attempt, self.ctx.attempts,
-                                      self.write_session.timeout,
-                                      old_timeout))
-                    self.stats.write_failed += 1
+                    log.info("Retry to write key: {0} attempts: {1}/{2} increased timeout: {3}/{4}"
+                             .format(repr(self.key), self.attempt, self.ctx.attempts,
+                                     self.write_session.timeout, old_timeout))
+                    self.stats.write_retries += 1
                     self.write()
                     return
-                self.stats.write_failed += 1
                 self.stop(False)
                 return
 
@@ -239,6 +305,34 @@ class KeyRecover(object):
                       .format(self.key, repr(e), traceback.format_exc()))
             self.stop(False)
 
+    def onremove(self, results, error):
+        try:
+            if error.code:
+                self.stats.remove_failed += 1
+                log.error("Failed to remove key: {0}: from groups: {1}: {2}"
+                          .format(self.key, self.remove_session.groups, error))
+                if self.attempt < self.ctx.attempts:
+                    old_timeout = self.remove_session.timeout
+                    self.remove_session.timeout *= 2
+                    self.attempt += 1
+                    log.info("Retry to remove key: {0} attempts: {1}/{2} "
+                             "increased timeout: {3}/{4}"
+                             .format(repr(self.key),
+                                     self.attempt, self.ctx.attempts,
+                                     self.remove_session.timeout,
+                                     old_timeout))
+                    self.stats.remove_retries += 1
+                    self.remove()
+                    return
+                self.stop(False)
+                return
+
+            self.stats.remove += len(results)
+            self.stop(True)
+        except:
+            log.exception("Failed to handle remove result key: {0} from groups: {1}"
+                          .format(self.key, self.remove_session.groups))
+
     def wait(self):
         if not self.complete.is_set():
             self.complete.wait()
@@ -258,13 +352,16 @@ def iterate_key(filepath, groups):
             key_infos = sorted(key_infos, key=lambda x: (x.timestamp, x.size), reverse=True)
             missed_groups = tuple(groups.difference([k.group_id for k in key_infos]))
 
-            #if all key_infos has the same timestamp and size and there is no missed groups - skip key, it is already up-to-date in all groups
-            if (key_infos[0].timestamp, key_infos[0].size) == (key_infos[-1].timestamp, key_infos[-1].size) and not missed_groups:
+            # if all key_infos has the same timestamp and size and there is no missed groups -
+            # skip key, it is already up-to-date in all groups
+            same_meta = lambda lhs, rhs: (lhs.timestamp, lhs.size) == (rhs.timestamp, rhs.size)
+            if same_meta(key_infos[0], key_infos[-1]) and not missed_groups:
                 continue
 
             yield (key, key_infos, missed_groups)
         else:
-            log.error("Invalid number of replicas for key: {0}: infos_count: {1}, groups_count: {2}".format(key, len(key_infos), len(groups)))
+            log.error("Invalid number of replicas for key: {0}: infos_count: {1}, groups_count: {2}"
+                      .format(key, len(key_infos), len(groups)))
 
 
 def recover(ctx):

--- a/recovery/elliptics_recovery/monitor.py
+++ b/recovery/elliptics_recovery/monitor.py
@@ -54,20 +54,23 @@ class StatsProxy(object):
     def counter(self, name, value):
         try:
             self.queue.put_nowait((self.prefix, self.COUNTER, name, value))
-        except Exception as e:
-            self.log.error("Got an error during counter update: {0}".format(e))
+        except:
+            self.log.exception('Failed to update counter')
+            raise
 
     def set_counter(self, name, value):
         try:
             self.queue.put_nowait((self.prefix, self.SET_COUNTER, name, value))
-        except Exception as e:
-            self.log.error("Got an error during counter update: {0}".format(e))
+        except:
+            self.log.exception('Failed to set counter')
+            raise
 
     def timer(self, name, milestone):
         try:
             self.queue.put_nowait((self.prefix, self.TIMER, name, milestone, datetime.now()))
-        except Exception as e:
-            self.log.error("Got an error during timer update: {0}".format(e))
+        except:
+            self.log.exception('Failed to update timer')
+            raise
 
     def __getitem__(self, item):
         prefix = item
@@ -145,13 +148,11 @@ class Monitor(object):
         while not self.__shutdown_request:
             try:
                 data = self.queue.get(block=True, timeout=1)
-            except EOFError:
-                break
             except Queue.Empty:
                 continue
-            except Exception as e:
-                self.log.error("Failed to wait on queue: {0}".format(e))
-                continue
+            except:
+                self.log.exception('Failed to wait on queue')
+                break
 
             try:
                 prefix = data[0]

--- a/recovery/elliptics_recovery/utils/misc.py
+++ b/recovery/elliptics_recovery/utils/misc.py
@@ -269,7 +269,6 @@ class RemoveDirect(DirectOperation):
                 return
 
             self.stats.remove += 1
-            #self.stats.removed_bytes += self.total_size
             self.callback(True, self.stats)
         except Exception as e:
             log.error("Onremove exception: {0}, traceback: {1}"
@@ -279,12 +278,13 @@ class RemoveDirect(DirectOperation):
 
 
 class KeyInfo(object):
-    def __init__(self, address, group_id, timestamp, size, user_flags):
+    def __init__(self, address, group_id, timestamp, size, user_flags, flags):
         self.address = address
         self.group_id = group_id
         self.timestamp = timestamp
         self.size = size
         self.user_flags = user_flags
+        self.flags = flags
 
     def dump(self):
         return (
@@ -292,7 +292,8 @@ class KeyInfo(object):
             self.group_id,
             (self.timestamp.tsec, self.timestamp.tnsec),
             self.size,
-            self.user_flags)
+            self.user_flags,
+            self.flags)
 
     @classmethod
     def load(cls, data):
@@ -300,7 +301,8 @@ class KeyInfo(object):
                    data[1],
                    elliptics.Time(data[2][0], data[2][1]),
                    data[3],
-                   data[4])
+                   data[4],
+                   data[5])
 
 
 def dump_key_data(key_data, file):

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,7 +69,7 @@ set_target_properties(dnet_backends_test ${TEST_PROPERTIES})
 target_link_libraries(dnet_backends_test ${TEST_LIBRARIES})
 
 
-set(PYTESTS_FLAGS "-l" "-x" "--timeout=300" "--durations=10")
+set(PYTESTS_FLAGS "-v" "-l" "-x" "--timeout=1200" "--durations=20")
 if(NOT WITH_COCAINE)
     list(APPEND PYTESTS_FLAGS "--without-cocaine")
 endif()

--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -131,7 +131,8 @@ def make_session(node, test_name, test_namespace=None):
 
 @pytest.fixture(scope='session')
 def elliptics_client(request):
-    ''' Initializes client connection to elliptics.
+    '''
+    Initializes client connection to elliptics.
     Returns Session object.
     '''
     remote = request.config.option.remotes
@@ -144,7 +145,7 @@ def elliptics_client(request):
     # return client
 
 
-@pytest.fixture(scope="session")
+@pytest.yield_fixture(scope="session")
 def server(request):
     groups = [int(g) for g in request.config.option.groups.split(',')]
 
@@ -156,8 +157,6 @@ def server(request):
     request.config.option.remotes = servers.remotes
     request.config.option.monitors = servers.monitors
 
-    def fin():
-        servers.stop()
-    request.addfinalizer(fin)
+    yield servers
 
-    return servers
+    servers.stop()

--- a/tests/pytests/test_session_monitor_and_statistics.py
+++ b/tests/pytests/test_session_monitor_and_statistics.py
@@ -346,7 +346,7 @@ def categories_combination():
     return list(set(combinations))
 
 
-class TestSession:
+class TestMonitor:
     def test_monitor_stat(self, server, simple_node):
         '''Simply get all statistics from all nodes and check that statistics is valid dict'''
         session = make_session(node=simple_node,


### PR DESCRIPTION
 * core: added common for all backends flag `DNET_RECORD_FLAGS_UNCOMMITTED` which is set for record is uncommitted and can't be read
 * iterator: made iterator collects uncommitted records
 * recovery: added handling uncommitted records, added options prepare-timeout which specifies timeout for uncommitted records after which such records should be deleted
 * recovery: fixed hanging on pool.close() - there is a bug in multiprocessing
 * pytests: added tests that checks new flag elliptics.record_flags.uncommitted:
   * serial of write_prepare, write_plain and write_commit with checking data accessibility
   * new tests of merge and dc recovery with mixing uncommitted keys into recovering keys.