### PR TITLE
Weights: split node weight to backends weights

### DIFF
--- a/library/backend.cpp
+++ b/library/backend.cpp
@@ -737,11 +737,10 @@ int dnet_cmd_backend_status(struct dnet_net_state *st, struct dnet_cmd *cmd, voi
 	const auto &backends = node->config_data->backends->backends;
 	const size_t total_size = sizeof(dnet_backend_status_list) + backends.size() * sizeof(dnet_backend_status);
 
-	std::unique_ptr<dnet_backend_status_list, free_destroyer> list(reinterpret_cast<dnet_backend_status_list *>(malloc(total_size)));
+	std::unique_ptr<dnet_backend_status_list, free_destroyer> list(reinterpret_cast<dnet_backend_status_list *>(calloc(1, total_size)));
 	if (!list) {
 		return -ENOMEM;
 	}
-	memset(list.get(), 0, total_size);
 
 	list->backends_count = backends.size();
 

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -90,14 +90,12 @@ static int dnet_cmd_route_list(struct dnet_net_state *orig, struct dnet_cmd *cmd
 	}
 
 	total_size = sizeof(struct dnet_addr_cmd) + states_num * n->addr_num * sizeof(struct dnet_addr);
-	acmd = malloc(total_size);
+	acmd = calloc(1, total_size);
 
 	if (!acmd) {
 		pthread_mutex_unlock(&n->state_lock);
 		return -ENOMEM;
 	}
-
-	memset(acmd, 0, total_size);
 
 //	cmd = &acmd->cmd;
 	acmd->cnt.addr_num = states_num * n->addr_num;
@@ -286,11 +284,9 @@ int dnet_send_reply(void *state, struct dnet_cmd *cmd, const void *odata, unsign
 	void *data;
 	int err;
 
-	c = malloc(sizeof(struct dnet_cmd) + size);
+	c = calloc(1, sizeof(struct dnet_cmd) + size);
 	if (!c)
 		return -ENOMEM;
-
-	memset(c, 0, sizeof(struct dnet_cmd) + size);
 
 	data = c + 1;
 	*c = *cmd;
@@ -1158,13 +1154,11 @@ int dnet_send_read_data(void *state, struct dnet_cmd *cmd, struct dnet_io_attr *
 
 	gettimeofday(&start_tv, NULL);
 
-	c = malloc(hsize);
+	c = calloc(1, hsize);
 	if (!c) {
 		err = -ENOMEM;
 		goto err_out_exit;
 	}
-
-	memset(c, 0, hsize);
 
 	rio = (struct dnet_io_attr *)(c + 1);
 

--- a/library/dnet_common.c
+++ b/library/dnet_common.c
@@ -401,14 +401,14 @@ void dnet_io_trans_alloc_send(struct dnet_session *s, struct dnet_io_control *ct
 	request_addr = dnet_state_addr(t->st);
 
 	dnet_log(n, DNET_LOG_INFO, "%s: created trans: %llu, cmd: %s, cflags: %s, size: %llu, offset: %llu, "
-			"fd: %d, local_offset: %llu -> %s weight: %f, backend_id: %d, wait-ts: %ld, ioflags: %s",
+			"fd: %d, local_offset: %llu -> %s/%d weight: %f, wait-ts: %ld, ioflags: %s",
 			dnet_dump_id(&ctl->id),
 			(unsigned long long)t->trans,
 			dnet_cmd_string(ctl->cmd), dnet_flags_dump_cflags(cmd->flags),
 			(unsigned long long)ctl->io.size, (unsigned long long)ctl->io.offset,
 			ctl->fd,
 			(unsigned long long)ctl->local_offset,
-		        dnet_addr_string(&t->st->addr), backend_weight, cmd->backend_id,
+		        dnet_addr_string(&t->st->addr), cmd->backend_id, backend_weight,
 			t->wait_ts.tv_sec,
 			dnet_flags_dump_ioflags(ctl->io.flags));
 

--- a/library/dnet_common.c
+++ b/library/dnet_common.c
@@ -468,13 +468,11 @@ struct dnet_wait *dnet_wait_alloc(int cond)
 	int err;
 	struct dnet_wait *w;
 
-	w = malloc(sizeof(struct dnet_wait));
+	w = calloc(1, sizeof(struct dnet_wait));
 	if (!w) {
 		err = -ENOMEM;
 		goto err_out_exit;
 	}
-
-	memset(w, 0, sizeof(struct dnet_wait));
 
 	err = pthread_cond_init(&w->wait, NULL);
 	if (err)

--- a/library/dnet_common.c
+++ b/library/dnet_common.c
@@ -514,6 +514,7 @@ int dnet_send_cmd(struct dnet_session *s,
 	struct dnet_net_state *st;
 	struct dnet_idc *idc;
 	int num = 0, i, found_group;
+	struct rb_node *it;
 	struct dnet_group *g;
 	struct dnet_trans_control ctl;
 
@@ -575,7 +576,9 @@ int dnet_send_cmd(struct dnet_session *s,
 			if (st == n->st)
 				continue;
 
-			list_for_each_entry(idc, &st->idc_list, state_entry) {
+			for (it = rb_first(&st->idc_root); it; it = rb_next(it)) {
+				idc = rb_entry(it, struct dnet_idc, state_entry);
+
 				g = idc->group;
 
 				found_group = 0;
@@ -886,6 +889,7 @@ int dnet_get_routes(struct dnet_session *s, struct dnet_route_entry **entries) {
 	struct dnet_idc *idc;
 	struct dnet_route_entry *tmp_entries;
 	struct dnet_route_entry *entry;
+	struct rb_node *it;
 	int size = 0, count = 0, err = 0;
 	int i;
 
@@ -893,7 +897,8 @@ int dnet_get_routes(struct dnet_session *s, struct dnet_route_entry **entries) {
 
 	pthread_mutex_lock(&n->state_lock);
 	list_for_each_entry(st, &n->dht_state_list, node_entry) {
-		list_for_each_entry(idc, &st->idc_list, state_entry) {
+		for (it = rb_first(&st->idc_root); it; it = rb_next(it)) {
+			idc = rb_entry(it, struct dnet_idc, state_entry);
 
 			size += idc->id_num;
 

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -160,6 +160,7 @@ struct dnet_net_state
 	struct list_head	storage_state_entry;
 	// Mapping backend_id -> struct dnet_idc
 	struct rb_root		idc_root;
+	pthread_rwlock_t        idc_lock;
 
 	struct dnet_node	*n;
 
@@ -209,7 +210,6 @@ struct dnet_net_state
 
 	int			la;
 	unsigned long long	free;
-	double			weight;
 
 	struct dnet_stat_count	stat[__DNET_CMD_MAX];
 
@@ -237,12 +237,12 @@ struct dnet_idc {
 	struct list_head	group_entry;
 	struct dnet_net_state	*st;
 	int			backend_id;
+	double			weight;
 	struct dnet_group	*group;
 	int			id_num;
 	struct dnet_state_id	ids[];
 };
 
-struct dnet_idc *dnet_idc_search_backend(struct dnet_net_state *st, int backend_id);
 int dnet_idc_insert(struct dnet_net_state *st, struct dnet_idc *idc);
 void dnet_idc_remove_backend_nolock(struct dnet_net_state *st, int backend_id);
 int dnet_idc_update_backend(struct dnet_net_state *st, struct dnet_backend_ids *ids);
@@ -264,6 +264,8 @@ void dnet_state_remove_nolock(struct dnet_net_state *st);
 struct dnet_net_state *dnet_state_search_by_addr(struct dnet_node *n, const struct dnet_addr *addr);
 struct dnet_net_state *dnet_state_get_first(struct dnet_node *n, const struct dnet_id *id);
 ssize_t dnet_state_search_backend(struct dnet_node *n, const struct dnet_id *id);
+int dnet_get_backend_weight(struct dnet_net_state *st, int backend_id, double *weight);
+void dnet_set_backend_weight(struct dnet_net_state *st, int backend_id, double weight);
 struct dnet_net_state *dnet_state_search_nolock(struct dnet_node *n, const struct dnet_id *id, int *backend_id);
 struct dnet_net_state *dnet_node_state(struct dnet_node *n);
 

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -160,6 +160,7 @@ struct dnet_net_state
 	struct list_head	storage_state_entry;
 	// Mapping backend_id -> struct dnet_idc
 	struct rb_root		idc_root;
+	// idc_lock is guard of idc_root structure, not values of idc_root items
 	pthread_rwlock_t        idc_lock;
 
 	struct dnet_node	*n;
@@ -232,6 +233,7 @@ struct dnet_state_id {
 	struct dnet_idc		*idc;
 };
 
+/* container of dnet_state_id */
 struct dnet_idc {
 	struct rb_node		state_entry;
 	struct list_head	group_entry;

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -158,8 +158,8 @@ struct dnet_net_state
 	struct list_head	node_entry;
 	// To store at node::storage_state_list (List of all network-active states, used for unsheduling process)
 	struct list_head	storage_state_entry;
-	// To store list of all idc connected with this state
-	struct list_head	idc_list;
+	// Mapping backend_id -> struct dnet_idc
+	struct rb_root		idc_root;
 
 	struct dnet_node	*n;
 
@@ -233,7 +233,7 @@ struct dnet_state_id {
 };
 
 struct dnet_idc {
-	struct list_head	state_entry;
+	struct rb_node		state_entry;
 	struct list_head	group_entry;
 	struct dnet_net_state	*st;
 	int			backend_id;
@@ -242,6 +242,8 @@ struct dnet_idc {
 	struct dnet_state_id	ids[];
 };
 
+struct dnet_idc *dnet_idc_search_backend(struct dnet_net_state *st, int backend_id);
+int dnet_idc_insert(struct dnet_net_state *st, struct dnet_idc *idc);
 void dnet_idc_remove_backend_nolock(struct dnet_net_state *st, int backend_id);
 int dnet_idc_update_backend(struct dnet_net_state *st, struct dnet_backend_ids *ids);
 void dnet_idc_destroy_nolock(struct dnet_net_state *st);

--- a/library/net.c
+++ b/library/net.c
@@ -944,11 +944,16 @@ int dnet_state_micro_init(struct dnet_net_state *st,
 	st->n = n;
 
 	st->la = 1;
-	st->weight = DNET_STATE_DEFAULT_WEIGHT;
 
 	INIT_LIST_HEAD(&st->node_entry);
 	INIT_LIST_HEAD(&st->storage_state_entry);
 	st->idc_root = RB_ROOT;
+	err = pthread_rwlock_init(&st->idc_lock, NULL);
+	if (err) {
+		err = -err;
+		dnet_log_err(n, "Failed to initialize idc_lock lock: err: %d", err);
+		goto err_out;
+	}
 
 	st->trans_root = RB_ROOT;
 	st->timer_root = RB_ROOT;
@@ -1246,6 +1251,7 @@ void dnet_state_destroy(struct dnet_net_state *st)
 
 	dnet_state_send_clean(st);
 
+	pthread_rwlock_destroy(&st->idc_lock);
 	pthread_mutex_destroy(&st->send_lock);
 	pthread_mutex_destroy(&st->trans_lock);
 

--- a/library/net.c
+++ b/library/net.c
@@ -948,7 +948,7 @@ int dnet_state_micro_init(struct dnet_net_state *st,
 
 	INIT_LIST_HEAD(&st->node_entry);
 	INIT_LIST_HEAD(&st->storage_state_entry);
-	INIT_LIST_HEAD(&st->idc_list);
+	st->idc_root = RB_ROOT;
 
 	st->trans_root = RB_ROOT;
 	st->timer_root = RB_ROOT;

--- a/library/net.c
+++ b/library/net.c
@@ -951,7 +951,7 @@ int dnet_state_micro_init(struct dnet_net_state *st,
 	err = pthread_rwlock_init(&st->idc_lock, NULL);
 	if (err) {
 		err = -err;
-		dnet_log_err(n, "Failed to initialize idc_lock lock: err: %d", err);
+		dnet_log(n, DNET_LOG_ERROR, "Failed to initialize idc_lock lock: err: %d", err);
 		goto err_out;
 	}
 
@@ -963,7 +963,7 @@ int dnet_state_micro_init(struct dnet_net_state *st,
 	err = pthread_mutex_init(&st->trans_lock, NULL);
 	if (err) {
 		err = -err;
-		dnet_log_err(n, "Failed to initialize transaction mutex: %d", err);
+		dnet_log(n, DNET_LOG_ERROR, "Failed to initialize transaction mutex: %d", err);
 		goto err_out;
 	}
 
@@ -971,14 +971,14 @@ int dnet_state_micro_init(struct dnet_net_state *st,
 	err = pthread_mutex_init(&st->send_lock, NULL);
 	if (err) {
 		err = -err;
-		dnet_log_err(n, "Failed to initialize send mutex: %d", err);
+		dnet_log(n, DNET_LOG_ERROR, "Failed to initialize send mutex: %d", err);
 		goto err_out_trans_destroy;
 	}
 
 	err = pthread_cond_init(&st->send_wait, NULL);
 	if (err) {
 		err = -err;
-		dnet_log_err(n, "Failed to initialize send cond: %d", err);
+		dnet_log(n, DNET_LOG_ERROR, "Failed to initialize send cond: %d", err);
 		goto err_out_send_destroy;
 	}
 

--- a/library/node.c
+++ b/library/node.c
@@ -34,12 +34,10 @@ static struct dnet_node *dnet_node_alloc(struct dnet_config *cfg)
 	struct dnet_node *n;
 	int err;
 
-	n = malloc(sizeof(struct dnet_node));
+	n = calloc(1, sizeof(struct dnet_node));
 	if (!n) {
 		goto err_out_free;
 	}
-
-	memset(n, 0, sizeof(struct dnet_node));
 
 	atomic_init(&n->trans, 0);
 
@@ -49,7 +47,7 @@ static struct dnet_node *dnet_node_alloc(struct dnet_config *cfg)
 
 	err = pthread_mutex_init(&n->state_lock, NULL);
 	if (err) {
-		dnet_log_err(n, "Failed to initialize state lock: err: %d", err);
+		dnet_log(n, DNET_LOG_ERROR, "Failed to initialize state lock: err: %d", err);
 		goto err_out_free;
 	}
 
@@ -68,14 +66,14 @@ static struct dnet_node *dnet_node_alloc(struct dnet_config *cfg)
 	err = pthread_mutex_init(&n->reconnect_lock, NULL);
 	if (err) {
 		err = -err;
-		dnet_log_err(n, "Failed to initialize reconnection lock: err: %d", err);
+		dnet_log(n, DNET_LOG_ERROR, "Failed to initialize reconnection lock: err: %d", err);
 		goto err_out_destroy_counter;
 	}
 
 	err = pthread_attr_init(&n->attr);
 	if (err) {
 		err = -err;
-		dnet_log_err(n, "Failed to initialize pthread attributes: err: %d", err);
+		dnet_log(n, DNET_LOG_ERROR, "Failed to initialize pthread attributes: err: %d", err);
 		goto err_out_destroy_reconnect_lock;
 	}
 	pthread_attr_setdetachstate(&n->attr, PTHREAD_CREATE_DETACHED);

--- a/library/node.c
+++ b/library/node.c
@@ -239,7 +239,7 @@ static struct dnet_idc *dnet_idc_search_backend_nolock(struct dnet_net_state *st
 	return NULL;
 }
 
-int dnet_idc_insert(struct dnet_net_state *st, struct dnet_idc *idc_new)
+int dnet_idc_insert_nolock(struct dnet_net_state *st, struct dnet_idc *idc_new)
 {
 	struct rb_root *root = &st->idc_root;
 	struct rb_node **n = &root->rb_node, *parent = NULL;
@@ -396,7 +396,7 @@ int dnet_idc_update_backend(struct dnet_net_state *st, struct dnet_backend_ids *
 	idc->weight = DNET_STATE_DEFAULT_WEIGHT;
 
 	pthread_rwlock_wrlock(&st->idc_lock);
-	dnet_idc_insert(st, idc);
+	dnet_idc_insert_nolock(st, idc);
 	pthread_rwlock_unlock(&st->idc_lock);
 	list_add_tail(&idc->group_entry, &g->idc_list);
 

--- a/library/node.c
+++ b/library/node.c
@@ -362,7 +362,7 @@ int dnet_idc_update_backend(struct dnet_net_state *st, struct dnet_backend_ids *
 
 		err = dnet_group_insert_nolock(n, g);
 		if (err)
-			goto err_out_unlock;
+			goto err_out_unlock_put;
 	}
 
 	dnet_idc_remove_backend_nolock(st, backend->backend_id);

--- a/library/notify.c
+++ b/library/notify.c
@@ -167,7 +167,7 @@ int dnet_notify_init(struct dnet_node *n)
 		err = pthread_rwlock_init(&b->notify_lock, NULL);
 		if (err) {
 			err = -err;
-			dnet_log_err(n, "Failed to initialize %d'th bucket lock: err: %d", i, err);
+			dnet_log(n, DNET_LOG_ERROR, "Failed to initialize %d'th bucket lock: err: %d", i, err);
 			goto err_out_free;
 		}
 	}

--- a/library/pool.c
+++ b/library/pool.c
@@ -170,13 +170,11 @@ int dnet_work_pool_alloc(struct dnet_work_pool_place *place, struct dnet_node *n
 
 	pthread_mutex_lock(&place->lock);
 
-	place->pool = malloc(sizeof(struct dnet_work_pool));
+	place->pool = calloc(1, sizeof(struct dnet_work_pool));
 	if (!place->pool) {
 		err = -ENOMEM;
 		goto err_out_exit;
 	}
-
-	memset(place->pool, 0, sizeof(struct dnet_work_pool));
 
 	err = pthread_mutex_init(&place->pool->lock, NULL);
 	if (err) {

--- a/library/route.cpp
+++ b/library/route.cpp
@@ -310,11 +310,10 @@ int dnet_route_list::send_all_ids_nolock(dnet_net_state *st, dnet_id *id, uint64
 		total_size += it->ids.size() * sizeof(dnet_raw_id);
 	}
 
-	void *buffer = std::malloc(total_size);
+	void *buffer = std::calloc(1, total_size);
 	if (!buffer)
 		return -ENOMEM;
 	std::unique_ptr<void, free_destroyer> buffer_guard(buffer);
-	memset(buffer, 0, total_size);
 
 	dnet_cmd *cmd = reinterpret_cast<dnet_cmd *>(buffer);
 	cmd->id = *id;

--- a/library/trans.c
+++ b/library/trans.c
@@ -274,8 +274,8 @@ void dnet_trans_destroy(struct dnet_trans *t)
 			if (st->stall) {
 				double backend_weight = 0.;
 				dnet_get_backend_weight(t->st, t->cmd.backend_id, &backend_weight);
-				dnet_log(st->n, DNET_LOG_INFO, "%s: reseting state stall counter: weight: %f, backend_id: %d",
-					 dnet_state_dump_addr(st), backend_weight, t->cmd.backend_id);
+				dnet_log(st->n, DNET_LOG_INFO, "%s/%d: reseting state stall counter: weight: %f",
+					 dnet_state_dump_addr(st), t->cmd.backend_id, backend_weight);
 			}
 
 			st->stall = 0;
@@ -426,13 +426,13 @@ int dnet_trans_alloc_send_state(struct dnet_session *s, struct dnet_net_state *s
 	req.hsize = sizeof(struct dnet_cmd) + ctl->size;
 	req.fd = -1;
 
-	dnet_log(n, DNET_LOG_INFO, "%s: alloc/send %s trans: %llu -> %s, weight: %f, backend_id: %d",
+	dnet_log(n, DNET_LOG_INFO, "%s: alloc/send %s trans: %llu -> %s/%d, weight: %f",
 			dnet_dump_id(&cmd->id),
 			dnet_cmd_string(ctl->cmd),
 			(unsigned long long)t->trans,
 			dnet_addr_string(&t->st->addr),
-			backend_weight,
-			cmd->backend_id
+			cmd->backend_id,
+			backend_weight
 		);
 
 	err = dnet_trans_send(t, &req);
@@ -515,7 +515,7 @@ void dnet_update_stall_backend_weights(struct list_head *stall_transactions)
 				dnet_set_backend_weight( st, t->cmd.backend_id, new_weight );
 			}
 
-			dnet_log(st->n, DNET_LOG_INFO, "%s: TIMEOUT: update backend weight: backend_id: %d, weight: %f -> %f",
+			dnet_log(st->n, DNET_LOG_INFO, "%s/%d: TIMEOUT: update backend weight: weight: %f -> %f",
 				 dnet_state_dump_addr(st), t->cmd.backend_id, old_weight, new_weight);
 		}
 	}

--- a/library/trans.c
+++ b/library/trans.c
@@ -215,11 +215,9 @@ struct dnet_trans *dnet_trans_alloc(struct dnet_node *n, uint64_t size)
 {
 	struct dnet_trans *t;
 
-	t = malloc(sizeof(struct dnet_trans) + size);
+	t = calloc(1, sizeof(struct dnet_trans) + size);
 	if (!t)
 		goto err_out_exit;
-
-	memset(t, 0, sizeof(struct dnet_trans) + size);
 
 	t->alloc_size = size;
 	t->n = n;
@@ -274,8 +272,10 @@ void dnet_trans_destroy(struct dnet_trans *t)
 
 		if (t->cmd.status != -ETIMEDOUT) {
 			if (st->stall) {
-				dnet_log(st->n, DNET_LOG_INFO, "%s: reseting state stall counter: weight: %f",
-						dnet_state_dump_addr(st), st->weight);
+				double backend_weight = 0.;
+				dnet_get_backend_weight(t->st, t->cmd.backend_id, &backend_weight);
+				dnet_log(st->n, DNET_LOG_INFO, "%s: reseting state stall counter: weight: %f, backend_id: %d",
+					 dnet_state_dump_addr(st), backend_weight, t->cmd.backend_id);
 			}
 
 			st->stall = 0;
@@ -289,12 +289,16 @@ void dnet_trans_destroy(struct dnet_trans *t)
 			struct dnet_io_attr *local_io = (struct dnet_io_attr *)(local_cmd + 1);
 			struct timeval io_tv;
 			char time_str[64];
-			double old_weight = st->weight;
+			double old_backend_weight = 0.;
+			double new_backend_weight = 0.;
 
 			if (st && (t->cmd.status == 0) && !(local_io->flags & DNET_IO_FLAGS_CACHE) && local_io->size) {
-				double norm = (double)diff / (double)local_io->size;
-
-				st->weight = 1.0 / ((1.0 / st->weight + norm) / 2.0);
+				const int err = dnet_get_backend_weight(st, t->cmd.backend_id, &old_backend_weight);
+				if (!err) {
+					const double norm = (double)diff / (double)local_io->size;
+					new_backend_weight = 1.0 / ((1.0 / old_backend_weight + norm) / 2.0);
+					dnet_set_backend_weight( st, t->cmd.backend_id, new_backend_weight );
+				}
 			}
 
 			io_tv.tv_sec = local_io->timestamp.tsec;
@@ -309,7 +313,7 @@ void dnet_trans_destroy(struct dnet_trans *t)
 				(unsigned long long)local_io->offset, (unsigned long long)local_io->size, (unsigned long long)local_io->total_size,
 				(unsigned long long)local_io->user_flags,
 				io_tv.tv_sec, io_tv.tv_usec, time_str, io_tv.tv_usec,
-				old_weight, st->weight);
+				old_backend_weight, new_backend_weight);
 		}
 
 		dnet_log(st->n, DNET_LOG_INFO, "%s: destruction %s trans: %llu, reply: %d, st: %s/%d, stall: %d, "
@@ -382,6 +386,7 @@ int dnet_trans_alloc_send_state(struct dnet_session *s, struct dnet_net_state *s
 	struct dnet_node *n = st->n;
 	struct dnet_cmd *cmd;
 	struct dnet_trans *t;
+	double backend_weight = 0.;
 	int err;
 
 	t = dnet_trans_alloc(n, sizeof(struct dnet_cmd) + ctl->size);
@@ -404,6 +409,8 @@ int dnet_trans_alloc_send_state(struct dnet_session *s, struct dnet_net_state *s
 	t->command = cmd->cmd;
 	cmd->trans = t->rcv_trans = t->trans = atomic_inc(&n->trans);
 
+	dnet_get_backend_weight(st, cmd->backend_id, &backend_weight);
+
 	memcpy(&t->cmd, cmd, sizeof(struct dnet_cmd));
 
 	if (ctl->size && ctl->data)
@@ -419,11 +426,14 @@ int dnet_trans_alloc_send_state(struct dnet_session *s, struct dnet_net_state *s
 	req.hsize = sizeof(struct dnet_cmd) + ctl->size;
 	req.fd = -1;
 
-	dnet_log(n, DNET_LOG_INFO, "%s: alloc/send %s trans: %llu -> %s, weight: %f.",
+	dnet_log(n, DNET_LOG_INFO, "%s: alloc/send %s trans: %llu -> %s, weight: %f, backend_id: %d",
 			dnet_dump_id(&cmd->id),
 			dnet_cmd_string(ctl->cmd),
 			(unsigned long long)t->trans,
-			dnet_addr_string(&t->st->addr), t->st->weight);
+			dnet_addr_string(&t->st->addr),
+			backend_weight,
+			cmd->backend_id
+		);
 
 	err = dnet_trans_send(t, &req);
 	if (err)
@@ -485,6 +495,29 @@ void dnet_trans_clean_list(struct list_head *head, int error)
 		}
 
 		dnet_trans_put(t);
+	}
+}
+
+void dnet_update_stall_backend_weights(struct list_head *stall_transactions)
+{
+	struct dnet_trans *t, *tmp;
+	struct dnet_net_state *st;
+	double old_weight, new_weight;
+
+	list_for_each_entry_safe(t, tmp, stall_transactions, trans_list_entry) {
+		st = t->st;
+
+		const int err = dnet_get_backend_weight(st, t->cmd.backend_id, &old_weight);
+		if (!err) {
+			new_weight = old_weight;
+			if (old_weight >= 2.) {
+				new_weight = old_weight / 10.;
+				dnet_set_backend_weight( st, t->cmd.backend_id, new_weight );
+			}
+
+			dnet_log(st->n, DNET_LOG_INFO, "%s: TIMEOUT: update backend weight: backend_id: %d, weight: %f -> %f",
+				 dnet_state_dump_addr(st), t->cmd.backend_id, old_weight, new_weight);
+		}
 	}
 }
 
@@ -632,11 +665,8 @@ static int dnet_trans_check_stall(struct dnet_net_state *st, struct list_head *h
 	if (trans_timeout) {
 		st->stall++;
 
-		if (st->weight >= 2)
-			st->weight /= 10;
-
-		dnet_log(st->n, DNET_LOG_ERROR, "%s: TIMEOUT: transactions: %d, stall counter: %d/%lu, weight: %f",
-				dnet_state_dump_addr(st), trans_timeout, st->stall, st->n->stall_count, st->weight);
+		dnet_log(st->n, DNET_LOG_ERROR, "%s: TIMEOUT: transactions: %d, stall counter: %d/%lu",
+				dnet_state_dump_addr(st), trans_timeout, st->stall, st->n->stall_count);
 
 		if (st->stall >= st->n->stall_count && st != st->n->st)
 			is_stall_state = 1;
@@ -679,6 +709,8 @@ static void dnet_check_all_states(struct dnet_node *n)
 		}
 	}
 	pthread_mutex_unlock(&n->state_lock);
+
+	dnet_update_stall_backend_weights(&head);
 
 	for (i = 0; i < num_stall_state; ++i) {
 		st = stall_states[i];

--- a/monitor/io_stat_provider.cpp
+++ b/monitor/io_stat_provider.cpp
@@ -39,7 +39,6 @@ void dump_states_stats(rapidjson::Value &stat, struct dnet_node *n, rapidjson::D
 		state_value.AddMember("send_queue_size", atomic_read(&st->send_queue_size), allocator)
 		           .AddMember("la", st->la, allocator)
 		           .AddMember("free", (uint64_t)st->free, allocator)
-		           .AddMember("weight", st->weight, allocator)
 		           .AddMember("stall", st->stall, allocator)
 		           .AddMember("join_state", st->__join_state, allocator);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,10 @@ add_executable(dnet_backends_test backends_test.cpp)
 set_target_properties(dnet_backends_test ${TEST_PROPERTIES})
 target_link_libraries(dnet_backends_test ${TEST_LIBRARIES})
 
+add_executable(dnet_weights_test weights_test.cpp)
+set_target_properties(dnet_weights_test ${TEST_PROPERTIES})
+target_link_libraries(dnet_weights_test ${TEST_LIBRARIES})
+
 
 set(PYTESTS_FLAGS "-v" "-l" "-x" "--timeout=1200" "--durations=20")
 if(NOT WITH_COCAINE)
@@ -76,7 +80,7 @@ endif()
 
 set(RUN_SERVERS_LIBRARIES ${TEST_LIBRARIES})
 
-set(TESTS_LIST dnet_cpp_test dnet_cpp_cache_test dnet_cpp_stats_test dnet_cpp_capped_test dnet_backends_test dnet_cpp_api_test)
+set(TESTS_LIST dnet_cpp_test dnet_cpp_cache_test dnet_cpp_stats_test dnet_cpp_capped_test dnet_backends_test dnet_weights_test dnet_cpp_api_test)
 set(TESTS_DEPS ${TESTS_LIST})
 
 if(WITH_COCAINE)

--- a/tests/pytests/test_session_monitor_and_statistics.py
+++ b/tests/pytests/test_session_monitor_and_statistics.py
@@ -142,7 +142,6 @@ class MonitorStatsChecker:
             assert state_io['send_queue_size'] >= 0
             assert state_io['la'] >= 0
             assert state_io['free'] >= 0
-            assert state_io['weight'] >= 0
             assert state_io['stall'] >= 0
             assert state_io['join_state'] >= 0
 

--- a/tests/test_base.hpp
+++ b/tests/test_base.hpp
@@ -239,6 +239,7 @@ struct start_nodes_config {
 	bool fork;
 	bool monitor;
 	bool isolated;
+	int client_node_flags;
 
 	start_nodes_config(std::ostream &debug_stream, const std::vector<server_config> &&configs, const std::string &path);
 };

--- a/tests/weights_test.cpp
+++ b/tests/weights_test.cpp
@@ -1,0 +1,171 @@
+/*
+ * 2015+ Copyright (c) Andrey Budnik <budnik27@gmail.com>
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+#include "test_base.hpp"
+#include "../library/elliptics.h"
+#include <algorithm>
+
+#define BOOST_TEST_NO_MAIN
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/program_options.hpp>
+
+using namespace ioremap::elliptics;
+using namespace boost::unit_test;
+
+namespace tests {
+
+static std::shared_ptr<nodes_data> global_data;
+
+static size_t groups_count = 3;
+static size_t nodes_count = 2;
+static size_t backends_count = 1;
+static size_t backend_delay = 500; // 0.5 sec
+static int slow_group_id = 2;
+
+static server_config default_value(int group)
+{
+	// Minimize number of threads
+	server_config server = server_config::default_value();
+	server.options
+		("io_thread_num", 1)
+		("nonblocking_io_thread_num", 1)
+		("net_thread_num", 1)
+		("caches_number", 1)
+	;
+
+	server.backends[0]("enable", true)("group", group);
+
+	server.backends.resize(backends_count, server.backends.front());
+
+	return server;
+}
+
+static void configure_nodes(const std::string &path)
+{
+	std::vector<server_config> servers;
+	for (size_t i = 0; i < groups_count; ++i) {
+		for (size_t j = 0; j < nodes_count; ++j) {
+			const int group = i + 1;
+			server_config server = default_value(group);
+			servers.push_back(server);
+		}
+	}
+
+	start_nodes_config start_config(results_reporter::get_stream(), std::move(servers), path);
+	start_config.fork = true;
+	start_config.client_node_flags = DNET_CFG_MIX_STATES;
+
+	global_data = start_nodes(start_config);
+}
+
+static void set_backends_delay_for_group(session &sess, int group)
+{
+	for (size_t i = 0; i < nodes_count; ++i) {
+		for (size_t j = 0; j < backends_count; ++j) {
+			const size_t node_id = (group - 1) * nodes_count + i;
+			const server_node &node = global_data->nodes[node_id];
+			sess.set_delay(node.remote(), j, backend_delay);
+		}
+	}
+}
+
+static void test_backend_weights(session &sess)
+{
+	const int num_keys = 10;
+	for (int i = 0; i < num_keys; ++i) {
+		const key id = std::string("key_") + std::to_string(static_cast<long long>(i));
+		const std::string data = "some_data";
+		ELLIPTICS_REQUIRE(async_write, sess.write_data(id, data, 0));
+	}
+
+	const int num_reads = 1000;
+	int num_slow_group_reads = 0;
+	for (int i = 0; i < num_reads; ++i) {
+		const key id = std::string("key_") + std::to_string(static_cast<long long>(i % num_keys));
+		auto async_result = sess.read_data(id, 0, 0);
+		async_result.wait();
+
+		read_result_entry read_result;
+		async_result.get(read_result);
+
+		const dnet_cmd *cmd = read_result.command();
+		const int group_id = cmd->id.group_id;
+		if ( group_id == slow_group_id )
+			++num_slow_group_reads;
+	}
+
+	const int max_reads_from_slow_group = 10;
+	BOOST_REQUIRE_MESSAGE(num_slow_group_reads < max_reads_from_slow_group,
+			      "Too much reads from slow group (it means that backend weights are not working or backend hardware is extremely slow): "
+			      "num_slow_group_reads: " + std::to_string(static_cast<long long>(num_slow_group_reads)) +
+			      ", max_reads_from_slow_group: " + std::to_string(static_cast<long long>(max_reads_from_slow_group)));
+}
+
+
+bool register_tests(test_suite *suite, node n)
+{
+	auto sess = create_session(n, { 1, 2, 3 }, 0, 0);
+	set_backends_delay_for_group(sess, slow_group_id);
+	ELLIPTICS_TEST_CASE(test_backend_weights, sess);
+
+	return true;
+}
+
+static void destroy_global_data()
+{
+	global_data.reset();
+}
+
+boost::unit_test::test_suite *register_tests(int argc, char *argv[])
+{
+	namespace bpo = boost::program_options;
+
+	bpo::variables_map vm;
+	bpo::options_description generic("Test options");
+
+	std::string path;
+
+	generic.add_options()
+			("help", "This help message")
+			("path", bpo::value(&path), "Path where to store everything")
+			;
+
+	bpo::store(bpo::parse_command_line(argc, argv, generic), vm);
+	bpo::notify(vm);
+
+	if (vm.count("help")) {
+		std::cerr << generic;
+		return NULL;
+	}
+
+	test_suite *suite = new test_suite("Local Test Suite");
+
+	configure_nodes(path);
+
+	register_tests(suite, *global_data->node);
+
+	return suite;
+}
+
+}
+
+int main(int argc, char *argv[])
+{
+	atexit(tests::destroy_global_data);
+
+	srand(time(0));
+	return unit_test_main(tests::register_tests, argc, argv);
+}


### PR DESCRIPTION
Issue: https://github.com/reverbrain/elliptics/issues/601

Main changes:
1) moved 'weight' from net_state to idc
2) net_state use rb-tree (mapping backend_id -> idc)
3) backend weight look up from net_state's rb-tree (idc_root)