### PR TITLE
Recovery

### DIFF
--- a/recovery/elliptics_recovery/recovery.py
+++ b/recovery/elliptics_recovery/recovery.py
@@ -123,7 +123,16 @@ def main(options, args):
 
     try:
         ctx.log_file = os.path.join(ctx.tmp_dir, options.elliptics_log)
-        ctx.log_level = int(options.elliptics_log_level)
+        try:
+            ctx.log_level = int(options.elliptics_log_level)
+        except:
+            ctx.log_level = options.elliptics_log_level
+
+        if isinstance(ctx.log_level, int):
+            ctx.log_level = elliptics.log_level.values[ctx.log_level]
+        else:
+            ctx.log_level = elliptics.log_level.names[ctx.log_level]
+
         ctx.dump_keys = options.dump_keys
         if options.debug:
             ch.setLevel(logging.DEBUG)

--- a/recovery/elliptics_recovery/recovery.py
+++ b/recovery/elliptics_recovery/recovery.py
@@ -55,6 +55,25 @@ def cleanup(path):
                 os.unlink(file_name)
 
 
+def get_routes(ctx):
+    log.debug('Requesting routes')
+
+    log.debug("Creating logger")
+    elog = elliptics.Logger(ctx.log_file, int(ctx.log_level))
+
+    log.debug("Creating node")
+    node = elliptics_create_node(address=ctx.address,
+                                 elog=elog,
+                                 wait_timeout=ctx.wait_timeout,
+                                 remotes=ctx.remotes)
+
+    log.debug("Creating session for: {0}".format(ctx.address))
+    session = elliptics_create_session(node=node, group=0)
+
+    log.debug("Parsing routing table")
+    return RouteList.from_session(session)
+
+
 # @profile
 def main(options, args):
     if len(args) > 1:
@@ -259,22 +278,7 @@ def main(options, args):
 
     log.debug("Using following context:\n{0}".format(ctx))
 
-    log.debug("Setting up elliptics client")
-
-    log.debug("Creating logger")
-    elog = elliptics.Logger(ctx.log_file, int(ctx.log_level))
-
-    log.debug("Creating node")
-    node = elliptics_create_node(address=ctx.address,
-                                 elog=elog,
-                                 wait_timeout=ctx.wait_timeout,
-                                 remotes=ctx.remotes)
-
-    log.debug("Creating session for: {0}".format(ctx.address))
-    session = elliptics_create_session(node=node, group=0)
-
-    log.debug("Parsing routing table")
-    ctx.routes = RouteList.from_session(session)
+    ctx.routes = get_routes(ctx)
     log.debug("Parsed routing table:\n{0}".format(ctx.routes))
     if not ctx.routes:
         raise RuntimeError("No routes was parsed from session")


### PR DESCRIPTION
* Moved gathering of route list into `get_routes()` at main process - made temporary node/session be freed after the route list is received.
* Allowed to use string value for '-L/--log-level'. Now log level can be specified by one of `debug`, `error`, `info`, `notice` or `warning`.