### PR TITLE
Fixes and optimizations

### DIFF
--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -1147,10 +1147,25 @@ err_out_exit:
 	return err;
 }
 
+
+/*
+ * dnet_blob_config_cleanup() stops and cleans up eblob if it is needed and
+ * frees memory allocated by config.
+ * There are 3 stages of backend:
+ *   1. config parsing
+ *   2. eblob initialization
+ *   3. cleaning up eblob and config
+ * In common case backend goes throught all 3 steps.
+ * But there is specific case (backends_stat_provider.cpp: @fill_disabled_backend_config()):
+ *   monitor subsystem for disabled backends makes only 1 and 3 stages and skips stage 2.
+ *   So when monitor makes stage 3, it has uninitialized eblob and
+ *   should cleanus up only config data.
+ */
 static void dnet_blob_config_cleanup(struct dnet_config_backend *b)
 {
 	struct eblob_backend_config *c = b->data;
 
+	/* do not cleans up eblob if it hasn't been initialized */
 	if (c->eblob)
 		eblob_backend_cleanup(c);
 

--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -988,7 +988,9 @@ static void eblob_backend_cleanup(void *priv)
 {
 	struct eblob_backend_config *c = priv;
 
-	eblob_cleanup(c->eblob);
+	if (c->eblob) {
+		eblob_cleanup(c->eblob);
+	}
 
 	pthread_mutex_destroy(&c->last_read_lock);
 	free(c->data.file);

--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -988,12 +988,9 @@ static void eblob_backend_cleanup(void *priv)
 {
 	struct eblob_backend_config *c = priv;
 
-	if (c->eblob) {
-		eblob_cleanup(c->eblob);
-	}
+	eblob_cleanup(c->eblob);
 
 	pthread_mutex_destroy(&c->last_read_lock);
-	free(c->data.file);
 }
 
 static int dnet_eblob_iterator(struct dnet_iterator_ctl *ictl, struct dnet_iterator_request *ireq, struct dnet_iterator_range *irange)
@@ -1154,7 +1151,10 @@ static void dnet_blob_config_cleanup(struct dnet_config_backend *b)
 {
 	struct eblob_backend_config *c = b->data;
 
-	eblob_backend_cleanup(c);
+	if (c->eblob)
+		eblob_backend_cleanup(c);
+
+	free(c->data.file);
 }
 
 static struct dnet_config_entry dnet_cfg_entries_blobsystem[] = {

--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -824,7 +824,8 @@ static int eblob_backend_command_handler(void *state, void *priv, struct dnet_cm
 	return err;
 }
 
-static int dnet_blob_set_sync(struct dnet_config_backend *b, char *key __unused, char *value)
+static int dnet_blob_set_sync(struct dnet_config_backend *b,
+                              const char *key __unused, const char *value)
 {
 	struct eblob_backend_config *c = b->data;
 
@@ -832,7 +833,8 @@ static int dnet_blob_set_sync(struct dnet_config_backend *b, char *key __unused,
 	return 0;
 }
 
-static int dnet_blob_set_data(struct dnet_config_backend *b, char *key __unused, char *file)
+static int dnet_blob_set_data(struct dnet_config_backend *b,
+                              const char *key __unused, const char *file)
 {
 	struct eblob_backend_config *c = b->data;
 	int err;
@@ -860,7 +862,8 @@ static int dnet_blob_set_data(struct dnet_config_backend *b, char *key __unused,
 	return 0;
 }
 
-static int dnet_blob_set_blob_size(struct dnet_config_backend *b, char *key, char *value)
+static int dnet_blob_set_blob_size(struct dnet_config_backend *b,
+                                   const char *key, const char *value)
 {
 	struct eblob_backend_config *c = b->data;
 	uint64_t val = strtoul(value, NULL, 0);
@@ -882,7 +885,8 @@ static int dnet_blob_set_blob_size(struct dnet_config_backend *b, char *key, cha
 	return 0;
 }
 
-static int dnet_blob_set_index_block_size(struct dnet_config_backend *b, char *key __unused, char *value)
+static int dnet_blob_set_index_block_size(struct dnet_config_backend *b,
+                                          const char *key __unused, const char *value)
 {
 	struct eblob_backend_config *c = b->data;
 
@@ -890,7 +894,8 @@ static int dnet_blob_set_index_block_size(struct dnet_config_backend *b, char *k
 	return 0;
 }
 
-static int dnet_blob_set_index_block_bloom_length(struct dnet_config_backend *b, char *key __unused, char *value)
+static int dnet_blob_set_index_block_bloom_length(struct dnet_config_backend *b,
+                                                  const char *key __unused, const char *value)
 {
 	struct eblob_backend_config *c = b->data;
 
@@ -898,14 +903,16 @@ static int dnet_blob_set_index_block_bloom_length(struct dnet_config_backend *b,
 	return 0;
 }
 
-static int dnet_blob_set_periodic_timeout(struct dnet_config_backend *b, char *key __unused, char *value) {
+static int dnet_blob_set_periodic_timeout(struct dnet_config_backend *b,
+                                          const char *key __unused, const char *value) {
 	struct eblob_backend_config *c = b->data;
 
 	c->data.periodic_timeout = strtoul(value, NULL, 0);
 	return 0;
 }
 
-static int dnet_blob_set_records_in_blob(struct dnet_config_backend *b, char *key __unused, char *value)
+static int dnet_blob_set_records_in_blob(struct dnet_config_backend *b,
+                                         const char *key __unused, const char *value)
 {
 	struct eblob_backend_config *c = b->data;
 	uint64_t val = strtoul(value, NULL, 0);
@@ -914,7 +921,8 @@ static int dnet_blob_set_records_in_blob(struct dnet_config_backend *b, char *ke
 	return 0;
 }
 
-static int dnet_blob_set_defrag_timeout(struct dnet_config_backend *b, char *key __unused, char *value)
+static int dnet_blob_set_defrag_timeout(struct dnet_config_backend *b,
+                                        const char *key __unused, const char *value)
 {
 	struct eblob_backend_config *c = b->data;
 
@@ -922,7 +930,8 @@ static int dnet_blob_set_defrag_timeout(struct dnet_config_backend *b, char *key
 	return 0;
 }
 
-static int dnet_blob_set_defrag_time(struct dnet_config_backend *b, char *key __unused, char *value)
+static int dnet_blob_set_defrag_time(struct dnet_config_backend *b,
+                                     const char *key __unused, const char *value)
 {
 	struct eblob_backend_config *c = b->data;
 
@@ -930,7 +939,8 @@ static int dnet_blob_set_defrag_time(struct dnet_config_backend *b, char *key __
 	return 0;
 }
 
-static int dnet_blob_set_defrag_splay(struct dnet_config_backend *b, char *key __unused, char *value)
+static int dnet_blob_set_defrag_splay(struct dnet_config_backend *b,
+                                      const char *key __unused, const char *value)
 {
 	struct eblob_backend_config *c = b->data;
 
@@ -938,7 +948,8 @@ static int dnet_blob_set_defrag_splay(struct dnet_config_backend *b, char *key _
 	return 0;
 }
 
-static int dnet_blob_set_defrag_percentage(struct dnet_config_backend *b, char *key __unused, char *value)
+static int dnet_blob_set_defrag_percentage(struct dnet_config_backend *b,
+                                           const char *key __unused, const char *value)
 {
 	struct eblob_backend_config *c = b->data;
 
@@ -946,7 +957,8 @@ static int dnet_blob_set_defrag_percentage(struct dnet_config_backend *b, char *
 	return 0;
 }
 
-static int dnet_blob_set_blob_flags(struct dnet_config_backend *b, char *key __unused, char *value)
+static int dnet_blob_set_blob_flags(struct dnet_config_backend *b,
+                                    const char *key __unused, const char *value)
 {
 	struct eblob_backend_config *c = b->data;
 

--- a/example/file_backend.c
+++ b/example/file_backend.c
@@ -414,7 +414,8 @@ static int file_backend_command_handler(void *state, void *priv, struct dnet_cmd
 	return err;
 }
 
-static int dnet_file_set_bit_number(struct dnet_config_backend *b, char *key __unused, char *value)
+static int dnet_file_set_bit_number(struct dnet_config_backend *b,
+                                    const char *key __unused, const char *value)
 {
 	struct file_backend_root *r = b->data;
 
@@ -422,7 +423,8 @@ static int dnet_file_set_bit_number(struct dnet_config_backend *b, char *key __u
 	return 0;
 }
 
-static int dnet_file_set_records_in_blob(struct dnet_config_backend *b, char *key __unused, char *value)
+static int dnet_file_set_records_in_blob(struct dnet_config_backend *b,
+	                                 const char *key __unused, const char *value)
 {
 	struct file_backend_root *r = b->data;
 
@@ -430,7 +432,8 @@ static int dnet_file_set_records_in_blob(struct dnet_config_backend *b, char *ke
 	return 0;
 }
 
-static int dnet_file_set_blob_size(struct dnet_config_backend *b, char *key __unused, char *value)
+static int dnet_file_set_blob_size(struct dnet_config_backend *b,
+                                   const char *key __unused, const char *value)
 {
 	struct file_backend_root *r = b->data;
 	uint64_t val = strtoul(value, NULL, 0);
@@ -448,7 +451,8 @@ static int dnet_file_set_blob_size(struct dnet_config_backend *b, char *key __un
 	return 0;
 }
 
-static int dnet_file_set_defrag_timeout(struct dnet_config_backend *b, char *key __unused, char *value)
+static int dnet_file_set_defrag_timeout(struct dnet_config_backend *b,
+                                        const char *key __unused, const char *value)
 {
 	struct file_backend_root *r = b->data;
 
@@ -456,7 +460,8 @@ static int dnet_file_set_defrag_timeout(struct dnet_config_backend *b, char *key
 	return 0;
 }
 
-static int dnet_file_set_defrag_percentage(struct dnet_config_backend *b, char *key __unused, char *value)
+static int dnet_file_set_defrag_percentage(struct dnet_config_backend *b,
+                                           const char *key __unused, const char *value)
 {
 	struct file_backend_root *r = b->data;
 
@@ -464,7 +469,8 @@ static int dnet_file_set_defrag_percentage(struct dnet_config_backend *b, char *
 	return 0;
 }
 
-static int dnet_file_set_sync(struct dnet_config_backend *b, char *key __unused, char *value)
+static int dnet_file_set_sync(struct dnet_config_backend *b,
+                              const char *key __unused, const char *value)
 {
 	struct file_backend_root *r = b->data;
 
@@ -472,7 +478,8 @@ static int dnet_file_set_sync(struct dnet_config_backend *b, char *key __unused,
 	return 0;
 }
 
-static int dnet_file_set_root(struct dnet_config_backend *b, char *key __unused, char *root)
+static int dnet_file_set_root(struct dnet_config_backend *b,
+                              const char *key __unused, const char *root)
 {
 	struct file_backend_root *r = b->data;
 	int err;

--- a/example/module_backend/core/module_backend_t.c
+++ b/example/module_backend/core/module_backend_t.c
@@ -72,7 +72,7 @@ static void dnet_module_config_cleanup(struct dnet_config_backend *b)
 	module_backend_cleanup(module_backend);
 }
 
-int read_config_string(char *value, char **result)
+int read_config_string(const char *value, char **result)
 {
 	int err;
 	char *value_copy = strdup(value);
@@ -87,7 +87,7 @@ err_out_exit:
 		return err;
 }
 
-int read_config_entry(struct dnet_config_backend *b, char *key, char *value)
+int read_config_entry(struct dnet_config_backend *b, const char *key, const char *value)
 {
 	struct module_backend_t *module_backend = b->data;
 	struct module_backend_config_t *backend_config = &module_backend->config;

--- a/include/elliptics/backends.h
+++ b/include/elliptics/backends.h
@@ -65,7 +65,8 @@ static inline char *file_backend_get_dir(const unsigned char *id, uint64_t bit_n
 struct dnet_config_backend;
 struct dnet_config_entry {
 	char		key[64];
-	int		(*callback)(struct dnet_config_backend *b, char *key, char *value);
+	int		(*callback)(struct dnet_config_backend *b,
+	                            const char *key, const char *value);
 };
 
 struct dnet_config_backend {

--- a/library/backend.cpp
+++ b/library/backend.cpp
@@ -275,11 +275,7 @@ int dnet_backend_init(struct dnet_node *node, size_t backend_id, int *state)
 
 	for (auto it = backend.options.begin(); it != backend.options.end(); ++it) {
 		const dnet_backend_config_entry &entry = *it;
-		/*
-		 * Copy value data into temporal buffer, since callback can modify it.
-		 */
-		std::vector<char> tmp(entry.value_template.begin(), entry.value_template.end());
-		entry.entry->callback(&backend.config, entry.entry->key, tmp.data());
+		entry.entry->callback(&backend.config, entry.entry->key, entry.value_template.data());
 	}
 
 	err = backend.config.init(&backend.config);

--- a/monitor/backends_stat_provider.cpp
+++ b/monitor/backends_stat_provider.cpp
@@ -153,9 +153,7 @@ static void fill_disabled_backend_config(rapidjson::Value &stat_value,
 
 		for (auto it = config_backend.options.begin(); it != config_backend.options.end(); ++it) {
 			const dnet_backend_config_entry &entry = *it;
-
-			std::vector<char> tmp(entry.value_template.begin(), entry.value_template.end());
-			entry.entry->callback(&config, entry.entry->key, tmp.data());
+			entry.entry->callback(&config, entry.entry->key, entry.value_template.data());
 		}
 
 		config.to_json(&config, &json_stat, &size);

--- a/monitor/backends_stat_provider.cpp
+++ b/monitor/backends_stat_provider.cpp
@@ -166,6 +166,7 @@ static void fill_disabled_backend_config(rapidjson::Value &stat_value,
 			                        allocator);
 		}
 		free(json_stat);
+		config.cleanup(&config);
 	} else {
 		rapidjson::Value config_value(rapidjson::kObjectType);
 		for (auto it = config_backend.options.begin(); it != config_backend.options.end(); ++it) {


### PR DESCRIPTION
Fixed small memory leak of `dnet_config_backend` - call cleanup.
Used const pointers for dnet_config_entry callback arguments and removed useless copying of value.