### PR TITLE
backend: added parsing backend_id by eblob_backend

### DIFF
--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -976,6 +976,15 @@ static int dnet_blob_set_blob_flags(struct dnet_config_backend *b,
 	return 0;
 }
 
+static int dnet_blob_set_backend_id(struct dnet_config_backend *b,
+                                    const char *key __unused, const char *value) {
+	struct eblob_backend_config *c = b->data;
+
+	c->data.stat_id = strtoul(value, NULL, 0);
+	return 0;
+}
+
+
 uint64_t eblob_backend_total_elements(void *priv) {
 	struct eblob_backend_config *r = priv;
 	return eblob_total_elements(r->eblob);
@@ -1195,7 +1204,8 @@ static struct dnet_config_entry dnet_cfg_entries_blobsystem[] = {
 	{"blob_size_limit", dnet_blob_set_blob_size},
 	{"index_block_size", dnet_blob_set_index_block_size},
 	{"index_block_bloom_length", dnet_blob_set_index_block_bloom_length},
-	{"periodic_timeout", dnet_blob_set_periodic_timeout}
+	{"periodic_timeout", dnet_blob_set_periodic_timeout},
+	{"backend_id", dnet_blob_set_backend_id}
 };
 
 static struct dnet_config_backend dnet_eblob_backend = {


### PR DESCRIPTION
`backend_id` is used to identify eblob instance at handystats statistics.