### PR TITLE
Recovery: fixes and optimizations

### DIFF
--- a/bindings/python/elliptics_session.cpp
+++ b/bindings/python/elliptics_session.cpp
@@ -877,10 +877,15 @@ void init_elliptics_session() {
 		              &elliptics_session::get_trace_id,
 		              &elliptics_session::set_trace_id,
 		    "Sets debug trace_id which will be printed in all logs\n"
-		    "connected with operations executed by the sesssion.\n"
-		    "All logs connected with operations executed by the session\n"
-		    "will be printed with ignoring current log level\n\n"
+		    "connected with operations executed by the sesssion\n\n"
 		    "session.trace_id = 123456")
+
+		.add_property("trace_bit",
+		              &elliptics_session::get_trace_bit,
+		              &elliptics_session::set_trace_bit,
+		    "If true, all logs connected with operations executed by the session\n"
+		    "will be printed with ignoring current log level\n\n"
+		    "session.trace_id = True")
 
 		.add_property("cflags",
 		              &elliptics_session::get_cflags,

--- a/bindings/python/src/log.py
+++ b/bindings/python/src/log.py
@@ -32,6 +32,37 @@ def logged_class(klass):
     return klass
 
 
+def convert_elliptics_log_level(level):
+    '''
+    Converts elliptics.log_level into logging log level
+    '''
+    if level <= elliptics.log_level.debug:
+        return logging.DEBUG
+    elif level <= elliptics.log_level.info:
+        return logging.INFO
+    elif level <= elliptics.log_level.warning:
+        return logging.WARNING
+    elif level <= elliptics.log_level.error:
+        return logging.ERROR
+    else:
+        return logging.ERROR
+
+def convert_logging_log_level(level):
+    '''
+    Converts logging log level into elliptics.log_level
+    '''
+    if level <= logging.DEBUG:
+        return elliptics.log_level.debug
+    elif level <= logging.INFO:
+        return elliptics.log_level.info
+    elif level <= logging.WARNING:
+        return elliptics.log_level.warning
+    elif level <= logging.CRITICAL:
+        return elliptics.log_level.ERROR
+    else:
+        return elliptics.log_level.error
+
+
 class Handler(logging.Handler):
     def __init__(self, path, level):
         logging.Handler.__init__(self)

--- a/recovery/elliptics_recovery/dc_recovery.py
+++ b/recovery/elliptics_recovery/dc_recovery.py
@@ -471,7 +471,7 @@ if __name__ == '__main__':
 
     ch = logging.StreamHandler(sys.stderr)
     ch.setFormatter(formatter)
-    ch.setLevel(logging.INFO)
+    ch.setLevel(logging.WARNING)
     log.addHandler(ch)
 
     if not os.path.exists(ctx.tmp_dir):
@@ -489,16 +489,17 @@ if __name__ == '__main__':
         ctx.merged_filename = os.path.join(ctx.tmp_dir,
                                            options.merged_filename)
 
-        ch.setLevel(logging.WARNING)
-        if options.debug:
-            ch.setLevel(logging.DEBUG)
-
         # FIXME: It may be inappropriate to use one log for both
         # elliptics library and python app, esp. in presence of auto-rotation
         fh = logging.FileHandler(ctx.log_file)
         fh.setFormatter(formatter)
-        fh.setLevel(logging.DEBUG)
+        fh.setLevel(convert_elliptics_log_level(ctx.log_level))
         log.addHandler(fh)
+        log.setLevel(convert_elliptics_log_level(ctx.log_level))
+
+        if options.debug:
+            log.setLevel(logging.DEBUG)
+            ch.setLevel(logging.DEBUG)
     except Exception as e:
         raise ValueError("Can't parse log_level: '{0}': {1}, traceback: {2}"
                          .format(options.elliptics_log_level, repr(e), traceback.format_exc()))

--- a/recovery/elliptics_recovery/dc_recovery.py
+++ b/recovery/elliptics_recovery/dc_recovery.py
@@ -42,11 +42,17 @@ class KeyRecover(object):
         self.missed_groups = list(missed_groups)
 
         self.read_session = elliptics.Session(node)
+        self.read_session.trace_id = ctx.trace_id
         self.read_session.set_filter(elliptics.filters.all)
+
         self.write_session = elliptics.Session(node)
+        self.write_session.trace_id = ctx.trace_id
         self.write_session.set_checker(elliptics.checkers.all)
+
         self.remove_session = elliptics.Session(node)
+        self.remove_session.trace_id = ctx.trace_id
         self.remove_session.set_checker(elliptics.checkers.all)
+
         self.result = False
         self.attempt = 0
 

--- a/recovery/elliptics_recovery/iterator.py
+++ b/recovery/elliptics_recovery/iterator.py
@@ -239,9 +239,10 @@ class Iterator(object):
     Wrapper on top of elliptics new iterator and it's result container
     """
 
-    def __init__(self, node, group, separately=False):
+    def __init__(self, node, group, separately=False, trace_id=0):
         self.session = elliptics.Session(node)
         self.session.groups = [group]
+        self.session.trace_id = trace_id
         self.separately = separately
 
     def get_key_range_id(self, key):
@@ -351,8 +352,8 @@ class Iterator(object):
     def iterate_with_stats(cls, node, eid, timestamp_range,
                            key_ranges, tmp_dir, address, group_id, backend_id, batch_size,
                            stats, flags, leave_file=False,
-                           separately=False):
-        iterator = cls(node, group_id, separately)
+                           separately=False, trace_id=0):
+        iterator = cls(node, group_id, separately, trace_id=trace_id)
         result = iterator.start(eid=eid,
                                 timestamp_range=timestamp_range,
                                 flags=flags,

--- a/recovery/elliptics_recovery/iterator.py
+++ b/recovery/elliptics_recovery/iterator.py
@@ -125,7 +125,7 @@ class IteratorResult(object):
                     gets new record from iterator while it key == minimum or end of node diffs is reached.
                 4.  If for some tuple all node diffs are processed - adds number of the tuple into remove list
                 5.  After that removes from tuple list all tuples from remove list
-                6.  Repeates step 1-6 while tuple list isn't empty
+                6.  Repeats step 1-6 while tuple list isn't empty
         """
         results = [d for d in results if d and len(d) != 0]
         if len(results) == 1:
@@ -144,12 +144,6 @@ class IteratorResult(object):
         elif len(results) != 0:
             return cls.__merge__(results, tmp_dir)
         return None
-
-    @classmethod
-    def combine(cls, results, tmp_dir):
-        results = [d for d in results if d and len(d) != 0]
-        if len(results) == 1:
-            import shutil
 
     @classmethod
     def __merge__(cls, results, tmp_dir):

--- a/recovery/elliptics_recovery/monitor.py
+++ b/recovery/elliptics_recovery/monitor.py
@@ -177,8 +177,10 @@ class Monitor(object):
                     counter = getattr(stats.counter, name)
                     if value > 0:
                         counter.success = value
-                    else:
+                    elif value < 0:
                         counter.failures = -value
+                    else:
+                        counter.success, counter.failures = 0, 0
                 elif flavour == StatsProxy.TIMER:
                     _, _, name, milestone, ts = data
                     timer = getattr(stats.timer, name, ts)

--- a/recovery/elliptics_recovery/recovery.py
+++ b/recovery/elliptics_recovery/recovery.py
@@ -26,6 +26,7 @@ from elliptics_recovery.etime import Time
 from elliptics_recovery.utils.misc import elliptics_create_node, elliptics_create_session, worker_init
 from elliptics_recovery.monitor import Monitor, ALLOWED_STAT_FORMATS
 from elliptics_recovery.ctx import Ctx
+from elliptics.log import convert_elliptics_log_level
 
 import elliptics
 from elliptics.log import formatter
@@ -35,7 +36,7 @@ log.setLevel(logging.DEBUG)
 
 ch = logging.StreamHandler(sys.stderr)
 ch.setFormatter(formatter)
-ch.setLevel(logging.INFO)
+ch.setLevel(logging.WARNING)
 log.addHandler(ch)
 
 TYPE_MERGE = 'merge'
@@ -140,15 +141,18 @@ def main(options, args):
             ctx.log_level = elliptics.log_level.names[ctx.log_level]
 
         ctx.dump_keys = options.dump_keys
-        if options.debug:
-            ch.setLevel(logging.DEBUG)
 
         # FIXME: It may be inappropriate to use one log for both
         # elliptics library and python app, esp. in presence of auto-rotation
         fh = logging.FileHandler(ctx.log_file)
         fh.setFormatter(formatter)
-        fh.setLevel(logging.DEBUG)
+        fh.setLevel(convert_elliptics_log_level(ctx.log_level))
         log.addHandler(fh)
+        log.setLevel(convert_elliptics_log_level(ctx.log_level))
+
+        if options.debug:
+            ch.setLevel(logging.DEBUG)
+            log.setLevel(logging.DEBUG)
     except Exception as e:
         raise ValueError("Can't parse log_level: '{0}': {1}, traceback: {2}"
                          .format(options.elliptics_log_level, repr(e), traceback.format_exc()))

--- a/recovery/elliptics_recovery/recovery.py
+++ b/recovery/elliptics_recovery/recovery.py
@@ -68,7 +68,7 @@ def get_routes(ctx):
                                  remotes=ctx.remotes)
 
     log.debug("Creating session for: {0}".format(ctx.address))
-    session = elliptics_create_session(node=node, group=0)
+    session = elliptics_create_session(node=node, group=0, trace_id=ctx.trace_id)
 
     log.debug("Parsing routing table")
     return RouteList.from_session(session)
@@ -92,6 +92,12 @@ def main(options, args):
     ctx.one_node = bool(options.one_node)
     ctx.custom_recover = options.custom_recover
     ctx.no_meta = options.no_meta and (options.timestamp is None)
+
+    try:
+        ctx.trace_id = int(options.trace_id, 16)
+    except Exception as e:
+        raise ValueError("Can't parse -T/--trace-id: '{0}': {1}, traceback: {2}"
+                         .format(options.trace_id, repr(e), traceback.format_exc()))
 
     if ctx.custom_recover:
         ctx.custom_recover = os.path.abspath(ctx.custom_recover)
@@ -399,4 +405,6 @@ def run(args=None):
     parser.add_option('-p', '--prepare-timeout', action='store', dest='prepare_timeout', default='1d',
                       help='Timeout for uncommitted records (prepared, but not committed).'
                       'Records that exceeded this timeout will be removed. [default: %default]')
+    parser.add_option('-T', '--trace-id', action='store', dest="trace_id", default='0',
+                      help='Marks all recovery commands by trace_id at both recovery and server logs. This option accepts hex strings. [default: %default]')
     return main(*parser.parse_args(args))

--- a/recovery/elliptics_recovery/types/dc.py
+++ b/recovery/elliptics_recovery/types/dc.py
@@ -70,7 +70,8 @@ def iterate_node(arg):
             stats=stats,
             flags=flags,
             leave_file=True,
-            separately=True)
+            separately=True,
+            trace_id=ctx.trace_id)
         if results is None or results_len == 0:
             return None
 
@@ -303,6 +304,7 @@ def lookup_keys(ctx):
                                  io_thread_num=1,
                                  remotes=ctx.remotes)
     session = elliptics.Session(node)
+    session.trace_id = ctx.trace_id
     filename = os.path.join(ctx.tmp_dir, 'merged_result')
     with open(filename, 'w') as merged_f:
         with open(ctx.dump_file, 'r') as dump_f:

--- a/recovery/elliptics_recovery/types/merge.py
+++ b/recovery/elliptics_recovery/types/merge.py
@@ -57,10 +57,12 @@ class Recovery(object):
         self.group = group
         self.node = node
         self.direct_session = elliptics.Session(node)
+        self.direct_session.trace_id = ctx.trace_id
         self.direct_session.set_direct_id(self.address, self.backend_id)
         self.direct_session.groups = [group]
         self.session = elliptics.Session(node)
         self.session.groups = [group]
+        self.session.trace_id = ctx.trace_id
         self.ctx = ctx
         self.stats = RecoverStat()
         self.result = True
@@ -344,7 +346,8 @@ def iterate_node(ctx, node, address, backend_id, ranges, eid, stats):
                                                          batch_size=ctx.batch_size,
                                                          stats=stats,
                                                          flags=flags,
-                                                         leave_file=False)
+                                                         leave_file=False,
+                                                         trace_id=ctx.trace_id)
         if result is None:
             return None
         log.info("Iterator {0}/{1} obtained: {2} record(s)"

--- a/recovery/elliptics_recovery/types/merge.py
+++ b/recovery/elliptics_recovery/types/merge.py
@@ -688,7 +688,7 @@ def dump_process_group((ctx, group)):
                                  remotes=ctx.remotes)
     ret = True
     with open(ctx.dump_file, 'r') as dump:
-        #splits ids from dump file in batchs and recovers it
+        # splits ids from dump file in batchs and recovers it
         for batch_id, batch in groupby(enumerate(dump), key=lambda x: x[0] / ctx.batch_size):
             recovers = []
             rs = RecoverStat()

--- a/recovery/elliptics_recovery/types/merge.py
+++ b/recovery/elliptics_recovery/types/merge.py
@@ -30,10 +30,9 @@ import os
 from itertools import groupby
 import traceback
 import threading
-import time
 
 from ..etime import Time
-from ..utils.misc import elliptics_create_node, RecoverStat, LookupDirect, RemoveDirect
+from ..utils.misc import elliptics_create_node, RecoverStat, LookupDirect, RemoveDirect, WindowedRecovery
 from ..route import RouteList
 from ..iterator import Iterator
 from ..range import IdRange
@@ -359,36 +358,51 @@ def iterate_node(ctx, node, address, backend_id, ranges, eid, stats):
         return None
 
 
+class WindowedMerge(WindowedRecovery):
+    def __init__(self, ctx, address, backend_id, group, node, results, stats):
+        super(WindowedMerge, self).__init__(ctx, stats)
+        self.address = address
+        self.backend_id = backend_id
+        self.group = group
+        self.node = node
+        self.results = iter(results)
+
+    def run_one(self):
+        try:
+            response = None
+            with self.lock:
+                response = next(self.results)
+                self.recovers_in_progress += 1
+            Recovery(key=response.key,
+                     timestamp=response.timestamp,
+                     size=response.size,
+                     flags=response.record_flags,
+                     address=self.address,
+                     backend_id=self.backend_id,
+                     group=self.group,
+                     ctx=self.ctx,
+                     node=self.node,
+                     callback=self.callback).run()
+            return True
+        except StopIteration:
+            pass
+        return False
+
+
 def recover(ctx, address, backend_id, group, node, results, stats):
     if results is None or len(results) < 1:
         log.warning("Recover skipped iterator results are empty for node: {0}/{1}"
                     .format(address, backend_id))
         return True
 
-    ret = True
-    start = time.time()
-    processed_keys = 0
-    for batch_id, batch in groupby(enumerate(results), key=lambda x: x[0] / ctx.batch_size):
-        recovers = []
-        rs = RecoverStat()
-        for _, response in batch:
-            rec = Recovery(key=response.key,
-                           timestamp=response.timestamp,
-                           size=response.size,
-                           flags=response.record_flags,
-                           address=address,
-                           backend_id=backend_id,
-                           group=group,
-                           ctx=ctx,
-                           node=node)
-            rec.run()
-            recovers.append(rec)
-        for r in recovers:
-            ret &= r.succeeded()
-            rs += r.stats
-        processed_keys += len(recovers)
-        rs.apply(stats)
-        stats.set_counter("recovery_speed", processed_keys / (time.time() - start))
+    ret = WindowedMerge(ctx=ctx,
+                        address=address,
+                        backend_id=backend_id,
+                        group=group,
+                        node=node,
+                        results=results,
+                        stats=stats).run()
+
     return ret
 
 

--- a/recovery/elliptics_recovery/utils/misc.py
+++ b/recovery/elliptics_recovery/utils/misc.py
@@ -73,11 +73,12 @@ def elliptics_create_node(address=None, elog=None, wait_timeout=3600, check_time
     return node
 
 
-def elliptics_create_session(node=None, group=None, cflags=elliptics.command_flags.default):
+def elliptics_create_session(node=None, group=None, cflags=elliptics.command_flags.default, trace_id=0):
     log.debug("Creating session: {0}@{1}.{2}".format(node, group, cflags))
     session = elliptics.Session(node)
     session.groups = [group]
     session.cflags = cflags
+    session.trace_id = trace_id
     return session
 
 
@@ -189,6 +190,7 @@ class DirectOperation(object):
         self.session.exceptions_policy = elliptics.core.exceptions_policy.no_exceptions
         # makes session direct to the address
         self.session.set_direct_id(address, backend_id)
+        self.session.trace_id = ctx.trace_id
         # sets groups
         self.session.groups = [group]
         self.id = id

--- a/recovery/elliptics_recovery/utils/misc.py
+++ b/recovery/elliptics_recovery/utils/misc.py
@@ -92,6 +92,9 @@ def worker_init():
 # common class for collecting statistics of recovering one key
 class RecoverStat(object):
     def __init__(self):
+        self.reset()
+
+    def reset(self):
         self.skipped = 0
         self.lookup = 0
         self.lookup_failed = 0
@@ -154,6 +157,8 @@ class RecoverStat(object):
             stats.counter('local_removes_old_bytes', self.remove_old_bytes)
         if self.merged_indexes:
             stats.counter("merged_indexes", self.merged_indexes)
+
+        self.reset()
 
     def __add__(self, b):
         ret = RecoverStat()

--- a/tests/pytests/test_recovery.py
+++ b/tests/pytests/test_recovery.py
@@ -30,6 +30,12 @@ class RECOVERY:
     DC = 2
 
 
+def cleanup_logger():
+    from logging import getLogger
+    log = getLogger()
+    log.handlers = []
+
+
 def check_backend_status(result, backend_id, state, defrag_state=0, last_start_err=0):
     '''
     Checks one backends status
@@ -149,6 +155,8 @@ def recovery(one_node, remotes, backend_id, address, groups,
         args += ['dc']
 
     assert run(args) == 0
+
+    cleanup_logger()
 
 
 @pytest.fixture(scope="class", autouse=True)

--- a/tests/pytests/test_session_iterator.py
+++ b/tests/pytests/test_session_iterator.py
@@ -36,14 +36,13 @@ def format_result(node, backend, result, counter):
         result.id)
 
 
-def format_stat(node, backend, result, counter):
+def format_stat(node, backend, result):
     '''
     Formats and returns string that represents iteration progress.
     '''
-    return "node: {0}/{1}: filtered_keys: {2} iterated_keys: {3}, total_keys: {4}".format(
+    return "node: {0}/{1}: iterated_keys: {2}, total_keys: {3}".format(
         node,
         backend,
-        counter,
         result.response.iterated_keys,
         result.response.total_keys)
 
@@ -74,7 +73,7 @@ def check_iterator_results(node, backend, iterator, session, node_id, no_meta=Fa
             session.continue_iterator(node_id, result.id)
 
         counter += 1
-        print format_result(node, backend, result, counter)
+        print format_result(node, backend, result)
 
 
 def convert_ranges(ranges):


### PR DESCRIPTION
Optimizations:
 * #598 - recover keys by window - do not wait until whole batch is recovered before start to recover keys from the next batch
 * #626 - allow to decrease logs by using `-L/--log-level` for both elliptics' and recovery's logs
 * added `-T/--trace-id` option to dnet_recovery - allow to mark servers' logs connected with recovery

Fixes:
 * fixed some recovery stats: `local_read*`, `recovered_keys*`, `remote_write*` etc.
 * removed `filtered_keys` because it is always equal to `iterated_key`