### PR TITLE
state: split backend weight into cache/disk pair

### DIFF
--- a/bindings/cpp/session.cpp
+++ b/bindings/cpp/session.cpp
@@ -24,7 +24,7 @@
 
 #include "node_p.hpp"
 
-#include "../../include/elliptics/async_result_cast.hpp"
+#include "elliptics/async_result_cast.hpp"
 
 namespace ioremap { namespace elliptics {
 
@@ -2223,7 +2223,7 @@ error_info session::mix_states(const key &id, std::vector<int> &groups)
 
 	dnet_id raw = id.id();
 
-	int num = dnet_mix_states(m_data->session_ptr, &raw, &groups_ptr.data());
+	int num = dnet_mix_states(m_data->session_ptr, &raw, get_ioflags(), &groups_ptr.data());
 	if (num < 0)
 		return create_error(num, "could not fetch groups");
 

--- a/include/elliptics/interface.h
+++ b/include/elliptics/interface.h
@@ -832,7 +832,7 @@ static inline int is_trans_destroyed(struct dnet_cmd *cmd)
 	return ret;
 }
 
-int dnet_mix_states(struct dnet_session *s, struct dnet_id *id, int **groupsp);
+int dnet_mix_states(struct dnet_session *s, struct dnet_id *id, uint32_t ioflags, int **groupsp);
 
 char * __attribute__((weak)) dnet_cmd_string(int cmd);
 const char *dnet_backend_state_string(uint32_t state);

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -240,7 +240,7 @@ struct dnet_idc {
 	struct list_head	group_entry;
 	struct dnet_net_state	*st;
 	int			backend_id;
-	double			weight;
+	double			disk_weight, cache_weight;
 	struct dnet_group	*group;
 	int			id_num;
 	struct dnet_state_id	ids[];
@@ -267,8 +267,8 @@ void dnet_state_remove_nolock(struct dnet_net_state *st);
 struct dnet_net_state *dnet_state_search_by_addr(struct dnet_node *n, const struct dnet_addr *addr);
 struct dnet_net_state *dnet_state_get_first(struct dnet_node *n, const struct dnet_id *id);
 ssize_t dnet_state_search_backend(struct dnet_node *n, const struct dnet_id *id);
-int dnet_get_backend_weight(struct dnet_net_state *st, int backend_id, double *weight);
-void dnet_set_backend_weight(struct dnet_net_state *st, int backend_id, double weight);
+int dnet_get_backend_weight(struct dnet_net_state *st, int backend_id, uint32_t ioflags, double *weight);
+void dnet_set_backend_weight(struct dnet_net_state *st, int backend_id, uint32_t ioflags, double weight);
 struct dnet_net_state *dnet_state_search_nolock(struct dnet_node *n, const struct dnet_id *id, int *backend_id);
 struct dnet_net_state *dnet_node_state(struct dnet_node *n);
 


### PR DESCRIPTION
Update them separately according to IO flags.

This should fix issue when there are obscure background disk operations while client is supposed to work in cache-only environment.