### PR TITLE
config: read_only option for backend

### DIFF
--- a/example/config.cpp
+++ b/example/config.cpp
@@ -332,6 +332,7 @@ void parse_backends(config_data *data, const config &backends)
 
 		dnet_backend_info &info = backends_info[backend_id];
 		info.enable_at_start = backend.at<bool>("enable", true);
+		info.read_only_at_start = backend.at<bool>("read_only", false);
 		info.state = DNET_BACKEND_DISABLED;
 		info.history = backend.at("history", std::string());
 

--- a/library/backend.cpp
+++ b/library/backend.cpp
@@ -272,6 +272,7 @@ int dnet_backend_init(struct dnet_node *node, size_t backend_id, int *state)
 
 	backend_io = &node->io->backends[backend_id];
 	backend_io->need_exit = 0;
+	backend_io->read_only = backend.read_only_at_start;
 
 	for (auto it = backend.options.begin(); it != backend.options.end(); ++it) {
 		const dnet_backend_config_entry &entry = *it;

--- a/library/backend.h
+++ b/library/backend.h
@@ -58,7 +58,7 @@ struct dnet_backend_info
 
 	dnet_backend_info(dnet_logger &logger, uint32_t backend_id) :
 		log(new dnet_logger(logger, make_attributes(backend_id))),
-		group(0), cache(NULL), enable_at_start(false),
+		group(0), cache(NULL), enable_at_start(false), read_only_at_start(false),
 		state_mutex(new std::mutex), state(DNET_BACKEND_UNITIALIZED),
 		io_thread_num(0), nonblocking_io_thread_num(0)
 	{
@@ -79,6 +79,7 @@ struct dnet_backend_info
 		cache(other.cache),
 		history(other.history),
 		enable_at_start(other.enable_at_start),
+		read_only_at_start(other.read_only_at_start),
 		state_mutex(std::move(other.state_mutex)),
 		state(other.state),
 		last_start(other.last_start),
@@ -100,6 +101,7 @@ struct dnet_backend_info
 		cache = other.cache;
 		history = other.history;
 		enable_at_start = other.enable_at_start;
+		read_only_at_start = other.read_only_at_start;
 		state_mutex = std::move(other.state_mutex);
 		state = other.state;
 		last_start = other.last_start;
@@ -122,6 +124,7 @@ struct dnet_backend_info
 	void *cache;
 	std::string history;
 	bool enable_at_start;
+	bool read_only_at_start;
 
 	std::unique_ptr<std::mutex> state_mutex;
 	dnet_backend_state state;


### PR DESCRIPTION
read_only option for backend makes backend read only at startup.