### PR TITLE
cleanup: stop all node thread pools, then destroy monitor, then clean…

### DIFF
--- a/library/backend.cpp
+++ b/library/backend.cpp
@@ -164,7 +164,7 @@ static int dnet_backend_io_init(struct dnet_node *n, struct dnet_backend_io *io,
 
 err_out_free_recv_pool:
 	n->need_exit = 1;
-	dnet_work_pool_cleanup(&io->pool.recv_pool);
+	dnet_work_pool_exit(&io->pool.recv_pool);
 err_out_command_stats_cleanup:
 	dnet_backend_command_stats_cleanup(io);
 err_out_exit:
@@ -175,8 +175,8 @@ static void dnet_backend_io_cleanup(struct dnet_node *n, struct dnet_backend_io 
 {
 	(void) n;
 
-	dnet_work_pool_cleanup(&io->pool.recv_pool);
-	dnet_work_pool_cleanup(&io->pool.recv_pool_nb);
+	dnet_work_pool_exit(&io->pool.recv_pool);
+	dnet_work_pool_exit(&io->pool.recv_pool_nb);
 	dnet_backend_command_stats_cleanup(io);
 
 	dnet_log(n, DNET_LOG_NOTICE, "dnet_backend_io_cleanup: backend: %zu", io->backend_id);

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -272,6 +272,9 @@ void dnet_set_backend_weight(struct dnet_net_state *st, int backend_id, uint32_t
 struct dnet_net_state *dnet_state_search_nolock(struct dnet_node *n, const struct dnet_id *id, int *backend_id);
 struct dnet_net_state *dnet_node_state(struct dnet_node *n);
 
+/* Set need_exit flag, cancel iterators, stop and join node threads */
+void dnet_node_stop_common_resources(struct dnet_node *n);
+/* Free resources of node. Must be called after dnet_node_stop_common_resources() */
 void dnet_node_cleanup_common_resources(struct dnet_node *n);
 
 int dnet_search_range(struct dnet_node *n, struct dnet_id *id,
@@ -464,7 +467,7 @@ struct dnet_work_pool_place
 	struct dnet_work_pool	*pool;
 };
 
-void dnet_work_pool_cleanup(struct dnet_work_pool_place *place);
+void dnet_work_pool_exit(struct dnet_work_pool_place *place);
 int dnet_work_pool_alloc(struct dnet_work_pool_place *place, struct dnet_node *n,
 	struct dnet_backend_io *io, int num, int mode, void *(* process)(void *));
 
@@ -516,7 +519,10 @@ int dnet_state_accept_process(struct dnet_net_state *st, struct epoll_event *ev)
 int dnet_io_init(struct dnet_node *n, struct dnet_config *cfg);
 void *dnet_io_process(void *data_);
 int dnet_server_io_init(struct dnet_node *n);
-void dnet_io_exit(struct dnet_node *n);
+/* Set need_exit flag, stop and join pool threads */
+void dnet_io_stop(struct dnet_node *n);
+/* Free pool resources of node. Must be called after dnet_io_stop() */
+void dnet_io_cleanup(struct dnet_node *n);
 
 void dnet_io_req_free(struct dnet_io_req *r);
 

--- a/library/server.c
+++ b/library/server.c
@@ -220,17 +220,17 @@ void dnet_server_node_destroy(struct dnet_node *n)
 	dnet_log(n, DNET_LOG_DEBUG, "Destroying server node.");
 
 	/*
-	 * Monitor uses all others, so it should be stopped at first.
+	 * Stop network and backend thread pools
+	 */
+	dnet_node_stop_common_resources(n);
+
+	/*
+	 * Monitor uses all others, so it should be stopped before cleaning node resources.
+	 * Also it should be stopped after stopping thread pools, because some requests
+	 * from i/o thread pool are processed in monitor.
 	 */
 	dnet_monitor_exit(n);
 
-	/*
-	 * Cache can be accessed from the io threads, so firstly stop them.
-	 * Cache uses backend to dump all ansynced data to the disk, so
-	 * backend must be destroyed the last.
-	 *
-	 * After all of them finish destroying the node, all it's counters and so on.
-	 */
 	dnet_node_cleanup_common_resources(n);
 
 	dnet_route_list_destroy(n->route);
@@ -249,4 +249,3 @@ void dnet_server_node_destroy(struct dnet_node *n)
 
 	free(n);
 }
-

--- a/monitor/monitor.cpp
+++ b/monitor/monitor.cpp
@@ -68,8 +68,8 @@ std::unique_ptr<monitor_config> monitor_config::parse(const elliptics::config::c
 
 monitor::monitor(struct dnet_node *n, struct dnet_config *cfg)
 : m_node(n)
-, m_server(*this, get_monitor_port(n), cfg->family)
 , m_statistics(*this, cfg)
+, m_server(*this, get_monitor_port(n), cfg->family)
 {
 #if defined(HAVE_HANDYSTATS) && !defined(HANDYSTATS_DISABLE)
 	if (cfg->handystats_config != nullptr) {

--- a/monitor/monitor.hpp
+++ b/monitor/monitor.hpp
@@ -77,8 +77,8 @@ public:
 
 private:
 	struct dnet_node	*m_node;
-	server		m_server;
 	statistics	m_statistics;
+	server		m_server;
 };
 
 monitor* get_monitor(struct dnet_node *n);


### PR DESCRIPTION
…up node thread pools

If pool threads are not stopped before cleaning monitor object, then some requests may use already destroyed monitor.