### PR TITLE
Timestamp cas

### DIFF
--- a/bindings/cpp/session.cpp
+++ b/bindings/cpp/session.cpp
@@ -984,7 +984,6 @@ async_write_result session::write_data(const dnet_io_attr &io, const argument_da
 async_write_result session::write_data(const key &id, const argument_data &file, uint64_t remote_offset)
 {
 	transform(id);
-	dnet_id raw = id.id();
 
 	dnet_io_control ctl;
 
@@ -999,7 +998,7 @@ async_write_result session::write_data(const key &id, const argument_data &file,
 	ctl.io.offset = remote_offset;
 	ctl.io.size = file.size();
 
-	memcpy(&ctl.id, &raw, sizeof(dnet_id));
+	ctl.id = id.id();
 
 	ctl.fd = -1;
 

--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -180,70 +180,6 @@ static int blob_lookup(struct eblob_backend *b, struct eblob_key *key, struct eb
 	return err;
 }
 
-static int blob_cas_timestamp(struct eblob_backend_config *c, struct eblob_key *key, struct dnet_io_attr *io)
-{
-	struct dnet_ext_list_hdr ehdr;
-	struct dnet_ext_list elist;
-	struct eblob_backend *b = c->eblob;
-	struct eblob_write_control wc = { .data_fd = -1 };
-	int err;
-
-	dnet_ext_list_init(&elist);
-
-	err = blob_lookup(b, key, &wc);
-	if (err < 0) {
-		if (err != -ENOENT) {
-			dnet_backend_log(c->blog, DNET_LOG_ERROR, "%s: EBLOB: blob-cas-timestamp: LOOKUP: %d: %s",
-				 dnet_dump_id_str(io->id), err, strerror(-err));
-			goto err_out_exit;
-		}
-
-		/* There is no record, write is safe. */
-		err = 0;
-		goto err_out_exit;
-	}
-
-	/* If it is data with extended header, we must check timestamp.
-	 * Otherwise allow overwrite.
-	 */
-	if (!(wc.flags & BLOB_DISK_CTL_EXTHDR)) {
-		err = 0;
-		goto err_out_exit;
-	}
-
-	/* Sanity */
-	if (wc.total_data_size < sizeof(struct dnet_ext_list_hdr)) {
-		err = -ERANGE;
-		goto err_out_exit;
-	}
-
-	err = dnet_ext_hdr_read(&ehdr, wc.data_fd, wc.data_offset);
-	if (err != 0)
-		goto err_out_exit;
-	dnet_ext_hdr_to_list(&ehdr, &elist);
-
-	/*
-	 * On-disk timestamp is higher than that in data to be written.
-	 * Do not allow this write.
-	 */
-	if (dnet_time_cmp(&elist.timestamp, &io->timestamp) > 0) {
-		dnet_backend_log(c->blog, DNET_LOG_ERROR, "%s: cas: disk timestamp is higher "
-				"than data to be written timestamp: disk-ts: %lld.%lld, data-ts: %lld.%lld",
-			dnet_dump_id_str(io->id),
-			(unsigned long long)elist.timestamp.tsec, (unsigned long long)elist.timestamp.tnsec,
-			(unsigned long long)io->timestamp.tsec, (unsigned long long)io->timestamp.tnsec);
-
-		err = -EBADFD;
-		goto err_out_exit;
-	}
-
-	err = 0;
-
-err_out_exit:
-	dnet_ext_list_destroy(&elist);
-	return err;
-}
-
 static int blob_write(struct eblob_backend_config *c, void *state,
 		struct dnet_cmd *cmd, void *data)
 {
@@ -277,16 +213,6 @@ static int blob_write(struct eblob_backend_config *c, void *state,
 		flags |= BLOB_DISK_CTL_NOCSUM;
 
 	memcpy(key.id, io->id, EBLOB_ID_SIZE);
-
-	/*
-	 * Check timestamp of the existing record if compare-and-swap timestamp flag is set.
-	 * If on-disk record's timestamp is higher than that in IO structure, do not allow this write.
-	 */
-	if (io->flags & DNET_IO_FLAGS_CAS_TIMESTAMP) {
-		err = blob_cas_timestamp(c, &key, io);
-		if (err)
-			goto err_out_exit;
-	}
 
 	if (io->flags & DNET_IO_FLAGS_PREPARE) {
 		/*
@@ -918,6 +844,69 @@ err_out_exit:
 	return err;
 }
 
+static int eblob_backend_lookup(struct dnet_node *n, void *priv, struct dnet_io_local *io)
+{
+	struct eblob_backend_config *c = priv;
+	struct eblob_backend *b = c->eblob;
+	struct eblob_key key;
+	struct dnet_ext_list_hdr ehdr;
+	struct dnet_ext_list elist;
+	struct eblob_write_control wc = { .data_fd = -1 };
+	uint64_t size, offset;
+	int err;
+
+	(void) n;
+	memcpy(key.id, io->key, EBLOB_ID_SIZE);
+
+	dnet_ext_list_init(&elist);
+
+	err = blob_lookup(b, &key, &wc);
+	if (err < 0) {
+		dnet_backend_log(c->blog, DNET_LOG_ERROR, "%s: EBLOB: blob-backend-lookup: LOOKUP: %d: %s",
+			 dnet_dump_id_str(io->key), err, strerror(-err));
+		goto err_out_exit;
+	}
+
+	io->record_flags = wc.flags;
+	io->fd = wc.data_fd;
+
+	size = wc.total_data_size;
+	offset = wc.data_offset;
+
+	if (!(wc.flags & BLOB_DISK_CTL_EXTHDR)) {
+		err = 0;
+		goto err_out_set_sizes;
+	}
+
+	/* Sanity */
+	if (wc.total_data_size < sizeof(struct dnet_ext_list_hdr)) {
+		err = -ERANGE;
+		goto err_out_set_sizes;
+	}
+
+	err = dnet_ext_hdr_read(&ehdr, wc.data_fd, wc.data_offset);
+	if (err != 0)
+		goto err_out_set_sizes;
+
+	dnet_ext_hdr_to_list(&ehdr, &elist);
+
+	io->timestamp = elist.timestamp;
+	io->user_flags = elist.flags;
+
+	size -= sizeof(struct dnet_ext_list_hdr);
+	offset += sizeof(struct dnet_ext_list_hdr);
+
+	err = 0;
+
+err_out_set_sizes:
+	io->total_size = size;
+	io->fd_offset = offset;
+
+err_out_exit:
+	dnet_ext_list_destroy(&elist);
+	return err;
+}
+
 static int blob_defrag_status(void *priv)
 {
 	struct eblob_backend_config *c = priv;
@@ -1479,6 +1468,7 @@ static int dnet_blob_config_init(struct dnet_config_backend *b)
 	b->cb.command_handler = eblob_backend_command_handler;
 	b->cb.backend_cleanup = eblob_backend_cleanup;
 	b->cb.checksum = eblob_backend_checksum;
+	b->cb.lookup = eblob_backend_lookup;
 
 	b->cb.iterator = dnet_eblob_iterator;
 

--- a/include/elliptics/interface.h
+++ b/include/elliptics/interface.h
@@ -215,6 +215,47 @@ int dnet_iterator_response_container_read(int fd, uint64_t pos,
 int64_t dnet_iterator_response_container_diff(int diff_fd, int left_fd, uint64_t left_size,
 		int right_fd, uint64_t right_size);
 
+/*
+ * This structure is used to get information about given key position
+ * in the underlying backend. Backend will not send anything to client,
+ * there is no @dnet_net_state for this.
+ */
+struct dnet_io_local
+{
+	uint8_t			key[DNET_ID_SIZE];
+
+	/*
+	 * @timestamp and @user_flags is used in extended headers in metadata writes.
+	 */
+	struct dnet_time	timestamp;
+	uint64_t		user_flags;
+
+	/*
+	 * Total size of the object.
+	 */
+	uint64_t		total_size;
+
+	/*
+	 * Combination of DNET_RECORD_FLAGS_*
+	 */
+	uint64_t		record_flags;
+
+	/*
+	 * If object can be read from file, backend may put appropriate fd here.
+	 */
+	int			fd;
+	uint64_t		fd_offset;
+
+	/*
+	 * This structure is not supposed to be transferred over the network,
+	 * so reserved fields are not needed - all backends live in elliptics source tree.
+	 *
+	 * But if there will be any external backend which can not be recompiled with
+	 * elliptics update, these fields may be useful.
+	 */
+	uint64_t		reserved[8];
+};
+
 struct dnet_backend_callbacks {
 	/* command handler processes DNET_CMD_* commands */
 	int			(* command_handler)(void *state, void *priv, struct dnet_cmd *cmd, void *data);
@@ -253,6 +294,8 @@ struct dnet_backend_callbacks {
 	 * Returns dir used by backend
 	 */
 	char *			(* dir)(void);
+
+	int			(* lookup)(struct dnet_node *n, void *priv, struct dnet_io_local *io);
 };
 
 /*

--- a/include/elliptics/packet.h
+++ b/include/elliptics/packet.h
@@ -550,7 +550,7 @@ static inline void dnet_convert_list(struct dnet_list *l)
  * to the timestamp of the on-disk record. This applies to prepare/commit writes too,
  * since prepare write command writes header which contains timestamp to disk.
  *
- * When both compare-and-swap and timestamp cas flags are specified, checksum cas is checked first.
+ * When both compare-and-swap and timestamp cas flags are specified, timestamp cas is checked first.
  */
 #define DNET_IO_FLAGS_CAS_TIMESTAMP	(1<<15)
 

--- a/include/elliptics/packet.h
+++ b/include/elliptics/packet.h
@@ -549,6 +549,8 @@ static inline void dnet_convert_list(struct dnet_list *l)
  * When set, it is only allowed to write data if its timestamp is higher or equal
  * to the timestamp of the on-disk record. This applies to prepare/commit writes too,
  * since prepare write command writes header which contains timestamp to disk.
+ *
+ * When both compare-and-swap and timestamp cas flags are specified, checksum cas is checked first.
  */
 #define DNET_IO_FLAGS_CAS_TIMESTAMP	(1<<15)
 
@@ -1015,8 +1017,9 @@ enum {
  */
 #define DNET_IFLAGS_MOVE		(1<<4)
 /*
- * Overwrite data. If this flag is not set, we only write data if there is no remote copy at all.
- * Data will still be transferred over the network.
+ * Overwrite data. If this flag is NOT set, we only write data if remote timestamp is less
+ * that that in data being written. When NOT set, data will still be transferred over the network,
+ * even if remote timestamp doesn't allow us to overwrite data.
  */
 #define DNET_IFLAGS_OVERWRITE		(1<<5)
 

--- a/include/elliptics/packet.h
+++ b/include/elliptics/packet.h
@@ -544,6 +544,14 @@ static inline void dnet_convert_list(struct dnet_list *l)
  */
 #define DNET_IO_FLAGS_WRITE_NO_FILE_INFO	(1<<14)
 
+/*
+ * Compare-and-set timestamp flag.
+ * When set, it is only allowed to write data if its timestamp is higher or equal
+ * to the timestamp of the on-disk record. This applies to prepare/commit writes too,
+ * since prepare write command writes header which contains timestamp to disk.
+ */
+#define DNET_IO_FLAGS_CAS_TIMESTAMP	(1<<15)
+
 static inline const char *dnet_flags_dump_ioflags(uint64_t flags)
 {
 	static __thread char buffer[256];

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -663,12 +663,12 @@ int dnet_server_send_write(struct dnet_server_send_ctl *send,
 	ctl.io.user_flags = re->user_flags;
 	ctl.io.total_size = re->size;
 	ctl.io.size = re->size;
-	ctl.io.flags = DNET_IO_FLAGS_WRITE_NO_FILE_INFO;
+	ctl.io.flags = DNET_IO_FLAGS_WRITE_NO_FILE_INFO | DNET_IO_FLAGS_CAS_TIMESTAMP;
 
-	// overwrite doesn't care whether remote key differs from local
-	// when this flag is not set, we only overwrite the same data or if there is no remote copy at all
-	if (!(send->iflags & DNET_IFLAGS_OVERWRITE))
-		ctl.io.flags |= DNET_IO_FLAGS_COMPARE_AND_SWAP;
+	// overwrite doesn't care whether remote timestamp differs from local
+	// when this flag is set, we overwrite data no matter what lives at destination node
+	if (send->iflags & DNET_IFLAGS_OVERWRITE)
+		ctl.io.flags &= ~DNET_IO_FLAGS_CAS_TIMESTAMP;
 
 	// deliberately do not set DNET_FLAGS_NEED_ACK
 	// if WRITE command has failed, @dnet_process_cmd_with_backend_raw() will set this bit automatically,

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -879,7 +879,6 @@ int dnet_process_indexes(struct dnet_backend_io *backend, struct dnet_net_state 
 int dnet_ids_update(struct dnet_node *n, int update_local, const char *file, struct dnet_addr *cfg_addrs, size_t backend_id);
 
 int __attribute__((weak)) dnet_remove_local(struct dnet_backend_io *backend, struct dnet_node *n, struct dnet_id *id);
-int __attribute__((weak)) dnet_cas_local(struct dnet_backend_io *backend, struct dnet_node *n, struct dnet_id *id, void *csum, int csize);
 
 /*
  * Internal iterator state


### PR DESCRIPTION
New IO flag which forbids overwriting data if its on-disk (or cached) timestamp is newer than that of data about to be written.
It is tested in server-send suite, by default server-send uses this flag and thus test where we write data with old timestamp and then try to move it to different groups where the same keys exist with newer timestamp. In this operation move should fail, i.e. all keys should not be moved, which implies keys will not be locally removed, and that's exactly what is tested.

Clearing timestamp cas bit (by setting iterator's overwrite flag) forces test to overwrite data, checking new content should succeed.