### PR TITLE
Ioflags mix states

### DIFF
--- a/bindings/python/elliptics_python.cpp
+++ b/bindings/python/elliptics_python.cpp
@@ -59,6 +59,7 @@ enum elliptics_cflags {
 
 enum elliptics_ioflags {
 	ioflags_default			= 0,
+	ioflags_mix_states		= DNET_IO_FLAGS_MIX_STATES,
 	ioflags_append			= DNET_IO_FLAGS_APPEND,
 	ioflags_prepare			= DNET_IO_FLAGS_PREPARE,
 	ioflags_commit			= DNET_IO_FLAGS_COMMIT,
@@ -421,6 +422,7 @@ BOOST_PYTHON_MODULE(core)
 		"cache_remove_from_disk\n    is set and object is being removed from cache,\n"
 		                        "    then remove object from disk too")
 		.value("default", ioflags_default)
+		.value("mix_states", ioflags_mix_states)
 		.value("append", ioflags_append)
 		.value("prepare", ioflags_prepare)
 		.value("commit", ioflags_commit)

--- a/bindings/python/elliptics_python.cpp
+++ b/bindings/python/elliptics_python.cpp
@@ -59,16 +59,18 @@ enum elliptics_cflags {
 
 enum elliptics_ioflags {
 	ioflags_default			= 0,
-	ioflags_mix_states		= DNET_IO_FLAGS_MIX_STATES,
 	ioflags_append			= DNET_IO_FLAGS_APPEND,
 	ioflags_prepare			= DNET_IO_FLAGS_PREPARE,
 	ioflags_commit			= DNET_IO_FLAGS_COMMIT,
 	ioflags_overwrite		= DNET_IO_FLAGS_OVERWRITE,
 	ioflags_nocsum			= DNET_IO_FLAGS_NOCSUM,
 	ioflags_plain_write		= DNET_IO_FLAGS_PLAIN_WRITE,
+	ioflags_nodata			= DNET_IO_FLAGS_NODATA,
 	ioflags_cache			= DNET_IO_FLAGS_CACHE,
 	ioflags_cache_only		= DNET_IO_FLAGS_CACHE_ONLY,
 	ioflags_cache_remove_from_disk	= DNET_IO_FLAGS_CACHE_REMOVE_FROM_DISK,
+	ioflags_cas_timestamp		= DNET_IO_FLAGS_CAS_TIMESTAMP,
+	ioflags_mix_states		= DNET_IO_FLAGS_MIX_STATES,
 };
 
 enum elliptics_record_flags {
@@ -420,19 +422,23 @@ BOOST_PYTHON_MODULE(core)
 		"cache_only\n    Means we do not want to sink to disk,\n"
 		            "    just return whatever cache processing returned (even error)\n"
 		"cache_remove_from_disk\n    is set and object is being removed from cache,\n"
-		                        "    then remove object from disk too")
+		                        "    then remove object from disk too"
+		"cas_timestamp\n    When set, write will only succeed if data timestamp is higher than timestamp stored on disk\n"
+		"mix_states\n    Read request with this flag forces replica selection according to their weights\n")
+
 		.value("default", ioflags_default)
-		.value("mix_states", ioflags_mix_states)
 		.value("append", ioflags_append)
 		.value("prepare", ioflags_prepare)
 		.value("commit", ioflags_commit)
 		.value("overwrite", ioflags_overwrite)
 		.value("nocsum", ioflags_nocsum)
 		.value("plain_write", ioflags_plain_write)
-		.value("nodata", ioflags_plain_write)
+		.value("nodata", ioflags_nodata)
 		.value("cache", ioflags_cache)
 		.value("cache_only", ioflags_cache_only)
 		.value("cache_remove_from_disk", ioflags_cache_remove_from_disk)
+		.value("cas_timestamp", ioflags_cas_timestamp)
+		.value("mix_states", ioflags_mix_states)
 	;
 
 	bp::enum_<elliptics_record_flags>("record_flags",

--- a/example/ioserv.json
+++ b/example/ioserv.json
@@ -30,9 +30,11 @@
 		"wait_timeout": 60,
 		"check_timeout": 60,
 		"io_thread_num": 16,
+		"stall_count": 3,
 		"nonblocking_io_thread_num": 16,
 		"net_thread_num": 4,
 		"daemon": false,
+		"parallel": true,
 		"auth_cookie": "qwerty",
 		"bg_ionice_class": 3,
 		"bg_ionice_prio": 0,
@@ -57,7 +59,9 @@
 			"blob_flags": "158",
 			"blob_size": "10G",
 			"records_in_blob": "1000000",
-			"periodic_timeout": 15
+			"periodic_timeout": 15,
+			"read_only": false,
+			"datasort_dir": "/opt/elliptics/defrag/"
 		}
 	]
 }

--- a/include/elliptics/packet.h
+++ b/include/elliptics/packet.h
@@ -474,12 +474,6 @@ static inline void dnet_convert_list(struct dnet_list *l)
 /* Internal server flag, used when we want to skip data sending */
 #define DNET_IO_FLAGS_SKIP_SENDING	(1<<0)
 
-/*
- * When set, force client to mix states according to their weights.
- * It deliberately matches DNET_IO_FLAGS_SKIP_SENDING above, since they can not be set simultaneously.
- */
-#define DNET_IO_FLAGS_MIX_STATES	(1<<0)
-
 /* Append given data at the end of the object */
 #define DNET_IO_FLAGS_APPEND		(1<<1)
 
@@ -560,11 +554,17 @@ static inline void dnet_convert_list(struct dnet_list *l)
  */
 #define DNET_IO_FLAGS_CAS_TIMESTAMP	(1<<15)
 
+/*
+ * When set, force client to mix states according to their weights.
+ */
+#define DNET_IO_FLAGS_MIX_STATES	(1<<16)
+
+
 static inline const char *dnet_flags_dump_ioflags(uint64_t flags)
 {
 	static __thread char buffer[256];
 	static struct flag_info infos[] = {
-		{ DNET_IO_FLAGS_MIX_STATES, "skip_sending/mix_states" },
+		{ DNET_IO_FLAGS_SKIP_SENDING, "skip_sending" },
 		{ DNET_IO_FLAGS_APPEND, "append" },
 		{ DNET_IO_FLAGS_PREPARE, "prepare" },
 		{ DNET_IO_FLAGS_COMMIT, "commit" },
@@ -579,6 +579,7 @@ static inline const char *dnet_flags_dump_ioflags(uint64_t flags)
 		{ DNET_IO_FLAGS_COMPARE_AND_SWAP, "cas" },
 		{ DNET_IO_FLAGS_CHECKSUM, "checksum/no_file_info" },
 		{ DNET_IO_FLAGS_CAS_TIMESTAMP, "cas_timestamp" },
+		{ DNET_IO_FLAGS_MIX_STATES, "mix_states" },
 	};
 
 	dnet_flags_dump_raw(buffer, sizeof(buffer), flags, infos, sizeof(infos) / sizeof(infos[0]));

--- a/include/elliptics/packet.h
+++ b/include/elliptics/packet.h
@@ -471,8 +471,14 @@ static inline void dnet_convert_list(struct dnet_list *l)
  * please also add it to elliptics_ioflags and to BOOST_PYTHON_MODULE(core) in elliptics_python.cpp
  */
 
-/* Internal flag, used when we want to skip data sending */
+/* Internal server flag, used when we want to skip data sending */
 #define DNET_IO_FLAGS_SKIP_SENDING	(1<<0)
+
+/*
+ * When set, force client to mix states according to their weights.
+ * It deliberately matches DNET_IO_FLAGS_SKIP_SENDING above, since they can not be set simultaneously.
+ */
+#define DNET_IO_FLAGS_MIX_STATES	(1<<0)
 
 /* Append given data at the end of the object */
 #define DNET_IO_FLAGS_APPEND		(1<<1)
@@ -558,7 +564,7 @@ static inline const char *dnet_flags_dump_ioflags(uint64_t flags)
 {
 	static __thread char buffer[256];
 	static struct flag_info infos[] = {
-		{ DNET_IO_FLAGS_SKIP_SENDING, "skip_sending" },
+		{ DNET_IO_FLAGS_MIX_STATES, "skip_sending/mix_states" },
 		{ DNET_IO_FLAGS_APPEND, "append" },
 		{ DNET_IO_FLAGS_PREPARE, "prepare" },
 		{ DNET_IO_FLAGS_COMMIT, "commit" },
@@ -571,8 +577,8 @@ static inline const char *dnet_flags_dump_ioflags(uint64_t flags)
 		{ DNET_IO_FLAGS_CACHE_ONLY, "cache_only" },
 		{ DNET_IO_FLAGS_CACHE_REMOVE_FROM_DISK, "remove_from_disk" },
 		{ DNET_IO_FLAGS_COMPARE_AND_SWAP, "cas" },
-		{ DNET_IO_FLAGS_CHECKSUM, "checksum" },
-		{ DNET_IO_FLAGS_WRITE_NO_FILE_INFO, "no_file_info" },
+		{ DNET_IO_FLAGS_CHECKSUM, "checksum/no_file_info" },
+		{ DNET_IO_FLAGS_CAS_TIMESTAMP, "cas_timestamp" },
 	};
 
 	dnet_flags_dump_raw(buffer, sizeof(buffer), flags, infos, sizeof(infos) / sizeof(infos[0]));

--- a/tests/pytests/test_session_parameters.py
+++ b/tests/pytests/test_session_parameters.py
@@ -20,7 +20,6 @@ from conftest import set_property, raises, make_session
 import elliptics
 
 io_flags = set((elliptics.io_flags.default,
-                elliptics.io_flags.mix_states,
                 elliptics.io_flags.append,
                 elliptics.io_flags.prepare,
                 elliptics.io_flags.commit,
@@ -30,7 +29,10 @@ io_flags = set((elliptics.io_flags.default,
                 elliptics.io_flags.nodata,
                 elliptics.io_flags.cache,
                 elliptics.io_flags.cache_only,
-                elliptics.io_flags.cache_remove_from_disk))
+                elliptics.io_flags.cache_remove_from_disk,
+                elliptics.io_flags.cas_timestamp,
+                elliptics.io_flags.mix_states,
+                ))
 
 command_flags = set((elliptics.command_flags.default,
                      elliptics.command_flags.direct,

--- a/tests/pytests/test_session_parameters.py
+++ b/tests/pytests/test_session_parameters.py
@@ -20,6 +20,7 @@ from conftest import set_property, raises, make_session
 import elliptics
 
 io_flags = set((elliptics.io_flags.default,
+                elliptics.io_flags.mix_states,
                 elliptics.io_flags.append,
                 elliptics.io_flags.prepare,
                 elliptics.io_flags.commit,

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1194,6 +1194,20 @@ static void test_read_latest_non_existing(session &sess, const std::string &id)
 	ELLIPTICS_REQUIRE_ERROR(read_data, sess.read_latest(id, 0, 0), -ENOENT);
 }
 
+// This test checks that read with DNET_IO_FLAGS_MIX_STATES succeeds and doesn't lock up.
+static void test_read_mix_states_ioflags(session &sess, const std::string &id)
+{
+	std::string data = "mix states test data";
+
+	sess.set_ioflags(sess.get_ioflags() | DNET_IO_FLAGS_MIX_STATES);
+
+	ELLIPTICS_REQUIRE(write_result, sess.write_data(id, data, 0));
+	ELLIPTICS_REQUIRE(read_result, sess.read_data(id, 0, 0));
+	read_result_entry result = read_result.get_one();
+
+	BOOST_REQUIRE_EQUAL(result.file().to_string(), data);
+}
+
 /*!
  * \brief test_merge_indexes
  *
@@ -1482,6 +1496,7 @@ bool register_tests(test_suite *suite, node n)
 	ELLIPTICS_TEST_CASE(test_lookup_non_existing, create_session(n, { 1, 2 }, 0, 0), -ENOENT);
 	ELLIPTICS_TEST_CASE(test_lookup_non_existing, create_session(n, { 1 }, 0, 0), -ENOENT);
 	ELLIPTICS_TEST_CASE(test_lookup_non_existing, create_session(n, { 99 }, 0, 0), -ENXIO);
+	ELLIPTICS_TEST_CASE(test_read_mix_states_ioflags, create_session(n, {1, 2}, 0, 0), "read-mix-states-ioflags");
 #ifndef NO_SERVER
 	ELLIPTICS_TEST_CASE(test_requests_to_own_server, create_session(node::from_raw(global_data->nodes.front().get_native()), { 1, 2, 3 }, 0, 0));
 #endif


### PR DESCRIPTION
New IO flag which forces client to mix states according to their weights.
Sometimes it is desired to only mix states for some requests and use strict order for others, this new IO flags allows just that.
Only created for weighted mix and not randomization, since the latter can be achieved in client.