### PR TITLE
iterator: automatically set key range flag when ranges are present

### DIFF
--- a/bindings/cpp/session.cpp
+++ b/bindings/cpp/session.cpp
@@ -2221,7 +2221,12 @@ async_iterator_result session::iterator(const key &id, const data_pointer& reque
 	ctl.cflags = DNET_FLAGS_NEED_ACK | DNET_FLAGS_NOLOCK;
 	ctl.cmd = DNET_CMD_ITERATOR;
 
-	dnet_convert_iterator_request(request.data<dnet_iterator_request>());
+	dnet_iterator_request *req = request.data<dnet_iterator_request>();
+	if (req->range_num)
+		req->flags |= DNET_IFLAGS_KEY_RANGE;
+
+	dnet_convert_iterator_request(req);
+
 	ctl.data = request.data();
 	ctl.size = request.size();
 

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -928,6 +928,15 @@ static int dnet_iterator_check_key_range(struct dnet_net_state *st, struct dnet_
 	char k1[2*DNET_ID_SIZE+1];
 	char k2[2*DNET_ID_SIZE+1];
 
+	if (ireq->range_num == 0) {
+		ireq->flags &= ~DNET_IFLAGS_KEY_RANGE;
+		return 0;
+	}
+
+	if (ireq->range_num != 0) {
+		ireq->flags |= DNET_IFLAGS_KEY_RANGE;
+	}
+
 	if (ireq->flags & DNET_IFLAGS_KEY_RANGE) {
 		struct dnet_raw_id empty_key = { .id = {} };
 
@@ -978,7 +987,7 @@ static int dnet_iterator_check_ts_range(struct dnet_net_state *st, struct dnet_c
 {
 	if (ireq->flags & DNET_IFLAGS_TS_RANGE) {
 		struct dnet_time empty_time = {0, 0};
-		/* Unset DNET_IFLAGS_KEY_RANGE if both times are empty */
+		/* Unset DNET_IFLAGS_TS_RANGE if both times are empty */
 		if (memcmp(&empty_time, &ireq->time_begin, sizeof(struct dnet_time)) == 0
 				&& memcmp(&empty_time, &ireq->time_end, sizeof(struct dnet_time) == 0)) {
 			dnet_log(st->n, DNET_LOG_NOTICE, "%s: both times are zero: cmd: %u",

--- a/tests/pytests/test_session_iterator.py
+++ b/tests/pytests/test_session_iterator.py
@@ -147,11 +147,15 @@ class TestSession:
         node_id, node, backend = iter(session.routes.get_unique_routes()[0])
         ranges = convert_ranges((session.routes.get_address_backend_ranges(node, backend)[0],))
 
+        # We could set flags=elliptics.iterator_flags.key_range,
+        # but it should be done automatically if there is at least one range.
+        # So this test also checks that behaviour.
+        flags = 0
         iterator = session.start_iterator(
             id=node_id,
             ranges=ranges,
             type=elliptics.iterator_types.network,
-            flags=elliptics.iterator_flags.key_range,
+            flags=flags,
             time_begin=elliptics.Time(0, 0),
             time_end=elliptics.Time(2 ** 64 - 1, 2 ** 64 - 1))
 


### PR DESCRIPTION
What about automatically setting iterator flags in cpp binding if there are ranges?