### PR TITLE
Fixed server_send() aggregation error

### DIFF
--- a/bindings/cpp/callback.cpp
+++ b/bindings/cpp/callback.cpp
@@ -68,6 +68,9 @@ public:
 		return false;
 	}
 
+	// how many independent transactions share this handler plus call below
+	// call below and corresponding +1 is needed, since transactions can be completed
+	// before send_impl() calls this method to setup this 'reference counter'
 	bool set_total(size_t total)
 	{
 		m_handler.set_total(total);

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -494,14 +494,18 @@ static int dnet_iterator_server_send_complete(struct dnet_addr *addr, struct dne
 			}
 
 err_out_send:
-			re->status = send->write_error;
+			if (send->write_error)
+				re->status = send->write_error;
+			if (!re->status)
+				re->status = err;
 
 			dnet_log(st->n, DNET_LOG_NOTICE, "%s: %s: sending response to client: %s, "
-					"user_flags: %llx, ts: %lld.%09lld, "
+					"user_flags: %llx, ts: %s (%lld.%09lld), "
 					"status: %d, size: %lld, iterated_keys: %lld/%lld, write_error: %d",
 					__func__,
 					dnet_dump_id(&send->cmd.id), dnet_dump_id_str(re->key.id),
 					(unsigned long long)re->user_flags,
+					dnet_print_time(&re->timestamp),
 					(unsigned long long)re->timestamp.tsec, (unsigned long long)re->timestamp.tnsec,
 					re->status, (unsigned long long)re->size,
 					(unsigned long long)re->iterated_keys, (unsigned long long)re->total_keys,

--- a/library/trans.c
+++ b/library/trans.c
@@ -458,16 +458,16 @@ int dnet_trans_alloc_send(struct dnet_session *s, struct dnet_trans_control *ctl
 	if (dnet_session_get_cflags(s) & DNET_FLAGS_DIRECT) {
 		st = dnet_state_search_by_addr(n, &s->direct_addr);
 		addr = &s->direct_addr;
-		if (!st) {
-			err = -ENXIO;
-			dnet_log(n, DNET_LOG_ERROR, "%s: %s: trans_send: could not find network state for address",
-				dnet_dump_id(&ctl->id), dnet_addr_string(&s->direct_addr));
-		}
 	} else {
 		st = dnet_state_get_first(n, &ctl->id);
 	}
 
 	if (!st) {
+		err = -ENXIO;
+		dnet_log(n, DNET_LOG_ERROR, "%s: direct: %d, direct-addr: %s: trans_send: could not find network state for address",
+			dnet_dump_id(&ctl->id),
+			!!(dnet_session_get_cflags(s) & DNET_FLAGS_DIRECT), dnet_addr_string(&s->direct_addr));
+
 		err = dnet_trans_send_fail(s, addr, ctl, -ENXIO, 1);
 	} else {
 		err = dnet_trans_alloc_send_state(s, st, ctl);

--- a/tests/server_send.cpp
+++ b/tests/server_send.cpp
@@ -153,9 +153,9 @@ static std::vector<dnet_raw_id> ssend_ids(session &s)
 	return ret;
 }
 
-static void ssend_test_copy(session &s, const std::vector<int> &dst_groups, int num, uint64_t iflags)
+static void ssend_test_copy(session &s, const std::vector<int> &dst_groups, int num, uint64_t iflags, int status)
 {
-	auto run_over_single_backend = [] (session &s, const key &id, const std::vector<int> &dst_groups, uint64_t iflags) {
+	auto run_over_single_backend = [] (session &s, const key &id, const std::vector<int> &dst_groups, uint64_t iflags, int status) {
 		std::vector<dnet_iterator_range> ranges;
 		dnet_iterator_range whole;
 		memset(whole.key_begin.id, 0, sizeof(dnet_raw_id));
@@ -173,27 +173,32 @@ static void ssend_test_copy(session &s, const std::vector<int> &dst_groups, int 
 
 		int copied = 0;
 
-		//char buffer[2*DNET_ID_SIZE + 1] = {0};
+		char buffer[2*DNET_ID_SIZE + 1] = {0};
 
 		logger &log = s.get_logger();
 
 		for (auto it = iter.begin(), end = iter.end(); it != end; ++it) {
-#if 0
+#if 1
 			// we have to explicitly convert all members from dnet_iterator_response
 			// since it is packed and there will be alignment issues and
 			// following error:
 			// error: cannot bind packed field ... to int&
 			BH_LOG(log, DNET_LOG_DEBUG,
 					"ssend_test: "
-					"key: %s, backend: %d, user_flags: %llx, ts: %lld.%09lld, status: %d, size: %lld, "
+					"key: %s, backend: %d, user_flags: %llx, ts: %s (%lld.%09lld), "
+					"status: %d (should be: %d), size: %lld, "
 					"iterated_keys: %lld/%lld",
 				dnet_dump_id_len_raw(it->reply()->key.id, DNET_ID_SIZE, buffer),
 				(int)it->command()->backend_id,
 				(unsigned long long)it->reply()->user_flags,
+				dnet_print_time(&it->reply()->timestamp),
 				(unsigned long long)it->reply()->timestamp.tsec, (unsigned long long)it->reply()->timestamp.tnsec,
-				(int)it->reply()->status, (unsigned long long)it->reply()->size,
+				(int)it->reply()->status, status, (unsigned long long)it->reply()->size,
 				(unsigned long long)it->reply()->iterated_keys, (unsigned long long)it->reply()->total_keys);
 #endif
+
+			BOOST_REQUIRE_EQUAL(it->command()->status, 0);
+			BOOST_REQUIRE_EQUAL(it->reply()->status, status);
 
 			if (iflags & DNET_IFLAGS_DATA) {
 				BOOST_REQUIRE_EQUAL(it->command()->size, sizeof(struct dnet_iterator_response) + it->reply()->size);
@@ -214,7 +219,7 @@ static void ssend_test_copy(session &s, const std::vector<int> &dst_groups, int 
 	int copied = 0;
 	std::vector<dnet_raw_id> ids = ssend_ids(s);
 	for (const auto &id: ids) {
-		copied += run_over_single_backend(s, id, dst_groups, iflags);
+		copied += run_over_single_backend(s, id, dst_groups, iflags, status);
 	}
 
 	BOOST_REQUIRE_EQUAL(copied, num);
@@ -244,6 +249,8 @@ static void ssend_test_server_send(session &s, int num, const std::string &id_pr
 	int copied = 0;
 	auto iter = s.server_send(keys, iflags, dst_groups);
 	for (auto it = iter.begin(), iter_end = iter.end(); it != iter_end; ++it) {
+		BOOST_REQUIRE_EQUAL(it->command()->status, 0);
+		BOOST_REQUIRE_EQUAL(it->reply()->status, 0);
 #if 0
 		// we have to explicitly convert all members from dnet_iterator_response
 		// since it is packed and there will be alignment issues and
@@ -290,7 +297,7 @@ static bool ssend_register_tests(test_suite *suite, node &n)
 	// per key, but also its data
 	ELLIPTICS_TEST_CASE(ssend_test_insert_many_keys, src, num, id_prefix, data_prefix);
 
-	ELLIPTICS_TEST_CASE(ssend_test_copy, src, ssend_dst_groups, num, iflags);
+	ELLIPTICS_TEST_CASE(ssend_test_copy, src, ssend_dst_groups, num, iflags, 0);
 	ELLIPTICS_TEST_CASE(ssend_test_read_many_keys_error, src, num, id_prefix, -ENOENT);
 
 	// check every dst group, it must contain all keys originally written into src groups
@@ -311,13 +318,14 @@ static bool ssend_register_tests(test_suite *suite, node &n)
 
 	// it should actually fail to move any key, since data is different and we
 	// do not set OVERWRITE bit, thus reading from source groups should succeeed
-	ELLIPTICS_TEST_CASE(ssend_test_copy, src, ssend_dst_groups, num, iflags);
+	// -EBADFD should be returned for cas/timestamp-cas errors
+	ELLIPTICS_TEST_CASE(ssend_test_copy, src, ssend_dst_groups, num, iflags, -EBADFD);
 	ELLIPTICS_TEST_CASE(ssend_test_read_many_keys, src, num, id_prefix, data_prefix);
 
 	// with OVERWRITE bit move should succeed - there should be no keys in @ssend_src_groups
 	// and all keys in @ssend_dst_groups should have been updated
 	iflags = DNET_IFLAGS_OVERWRITE | DNET_IFLAGS_MOVE;
-	ELLIPTICS_TEST_CASE(ssend_test_copy, src, ssend_dst_groups, num, iflags);
+	ELLIPTICS_TEST_CASE(ssend_test_copy, src, ssend_dst_groups, num, iflags, 0);
 	ELLIPTICS_TEST_CASE(ssend_test_read_many_keys_error, src, num, id_prefix, -ENOENT);
 
 	for (auto g = ssend_dst_groups.begin(), gend = ssend_dst_groups.end(); g != gend; ++g) {
@@ -344,7 +352,7 @@ static bool ssend_register_tests(test_suite *suite, node &n)
 	data_prefix = "plain iterator data";
 	ELLIPTICS_TEST_CASE(ssend_test_insert_many_keys, src, num, id_prefix, data_prefix);
 
-	ELLIPTICS_TEST_CASE(ssend_test_copy, src, ssend_dst_groups, num, iflags);
+	ELLIPTICS_TEST_CASE(ssend_test_copy, src, ssend_dst_groups, num, iflags, 0);
 	ELLIPTICS_TEST_CASE(ssend_test_read_many_keys, src, num, id_prefix, data_prefix);
 	for (auto g = ssend_dst_groups.begin(), gend = ssend_dst_groups.end(); g != gend; ++g) {
 		ELLIPTICS_TEST_CASE(ssend_test_read_many_keys,


### PR DESCRIPTION
After request has been completed, final ack will be processed both by common callback and iterator callback checkers. The latter will fail, since final ack doesn't bring any data.
This is generally worked around by using clean session clones (without checkers) and forcing aggregator to only work with clean session, i.e. apply all checkers on final aggregated results, not at intermediate replies.