### PR TITLE
Server send dynamic queue

### DIFF
--- a/bindings/cpp/session.cpp
+++ b/bindings/cpp/session.cpp
@@ -2244,7 +2244,8 @@ error_info session::mix_states(const key &id, std::vector<int> &groups)
 
 	int num = dnet_mix_states(m_data->session_ptr, &raw, get_ioflags(), &groups_ptr.data());
 	if (num < 0)
-		return create_error(num, "could not fetch groups");
+		return create_error(num, id, "could not fetch groups, num: %zd, ioflags: %s",
+				groups.size(), dnet_flags_dump_ioflags(get_ioflags()));
 
 	groups.assign(groups_ptr.data(), groups_ptr.data() + num);
 

--- a/example/iterate_move.cpp
+++ b/example/iterate_move.cpp
@@ -69,7 +69,7 @@ static void run_on_single_backend(const bpo::variables_map &vm,
 		elliptics::session &s, const dnet_id &id)
 {
 	// checking iterator flags
-	uint64_t iflags = DNET_IFLAGS_NO_META;
+	uint64_t iflags = 0;
 
 	if (vm.count("overwrite")) {
 		iflags |= DNET_IFLAGS_OVERWRITE;

--- a/example/iterate_move.cpp
+++ b/example/iterate_move.cpp
@@ -178,6 +178,7 @@ int main(int argc, char *argv[])
 	std::string log_file, log_level;
 	int igroup;
 	std::vector<uint32_t> backends;
+	long wait_timeout;
 	bpo::options_description ell("Elliptics options");
 	ell.add_options()
 		("remote,r", bpo::value<std::vector<std::string>>(&remotes)->required()->composing(),
@@ -185,6 +186,7 @@ int main(int argc, char *argv[])
 		("group,g", bpo::value<int>(&igroup)->required(), "single remote group to iterate over")
 		("log-file", bpo::value<std::string>(&log_file)->default_value("/dev/stdout"), "log file")
 		("log-level", bpo::value<std::string>(&log_level)->default_value("error"), "log level: error, info, notice, debug")
+		("wait-timeout,w", bpo::value<long>(&wait_timeout)->default_value(120), "wait timeout in seconds")
 		("backend,b", bpo::value<std::vector<uint32_t>>(&backends)->composing(),
 		 	"remote backends in specified group, if not specified, iteration will run over all backends, "
 			"can be specified multiple times")
@@ -242,7 +244,7 @@ int main(int argc, char *argv[])
 
 
 		elliptics::session s(node);
-		s.set_timeout(120);
+		s.set_timeout(wait_timeout);
 		s.set_groups({igroup});
 		std::vector<dnet_route_entry> routes = s.get_routes();
 		if (routes.empty()) {

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -319,7 +319,7 @@ static void dnet_queue_wait_threshold(struct dnet_net_state *st)
 	/* If send succeeded then we should increase queue size */
 	while ((atomic_read(&st->send_queue_size) > DNET_SEND_WATERMARK_HIGH) && !st->__need_exit) {
 		/* If high watermark is reached we should sleep */
-		dnet_log(st->n, DNET_LOG_DEBUG,
+		dnet_log(st->n, DNET_LOG_ERROR,
 				"State high_watermark reached: %s: %ld, sleeping",
 				dnet_addr_string(&st->addr),
 				atomic_read(&st->send_queue_size));
@@ -331,7 +331,7 @@ static void dnet_queue_wait_threshold(struct dnet_net_state *st)
 			pthread_cond_wait(&st->send_wait, &st->send_lock);
 		pthread_mutex_unlock(&st->send_lock);
 
-		dnet_log(st->n, DNET_LOG_DEBUG, "State woken up: %s: %ld",
+		dnet_log(st->n, DNET_LOG_ERROR, "State woken up: %s: %ld",
 				dnet_addr_string(&st->addr),
 				atomic_read(&st->send_queue_size));
 	}
@@ -517,7 +517,7 @@ err_out_send:
 			if (err && !send->write_error)
 				send->write_error = err;
 
-			if (atomic_sub(&send->bytes_pending, resize) < DNET_SERVER_SEND_WATERMARK_LOW)
+			if ((atomic_sub(&send->bytes_pending, resize) < DNET_SERVER_SEND_WATERMARK_LOW) || send->write_error)
 				pthread_cond_broadcast(&send->write_wait);
 
 			dnet_server_send_put(send);

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -517,7 +517,7 @@ err_out_send:
 				new_pending = 5 * re->size * 1000000 / usec;
 			}
 
-			dnet_log(st->n, DNET_LOG_NOTICE, "%s: %s: sending response to client: %s, "
+			dnet_log(st->n, DNET_LOG_INFO, "%s: %s: sending response to client: %s, "
 					"user_flags: %llx, ts: %s (%lld.%09lld), "
 					"status: %d, size: %lld, iterated_keys: %lld/%lld, write_error: %d, "
 					"pending_bytes: %ld, limit: %ld -> %ld",
@@ -760,7 +760,7 @@ int dnet_server_send_write(struct dnet_server_send_ctl *send,
 
 	atomic_add(&send->bytes_pending, re->size);
 
-	dnet_log(n, DNET_LOG_NOTICE, "%s: %s: sending WRITE request, iterator response: %s, user_flags: %llx, ts: %s (%lld.%09lld), "
+	dnet_log(n, DNET_LOG_INFO, "%s: %s: sending WRITE request, iterator response: %s, user_flags: %llx, ts: %s (%lld.%09lld), "
 			"status: %d, size: %lld, iterated_keys: %lld/%lld",
 			__func__,
 			dnet_dump_id(&send->cmd.id), dnet_dump_id_str(re->key.id),

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -319,8 +319,8 @@ static void dnet_queue_wait_threshold(struct dnet_net_state *st)
 	/* If send succeeded then we should increase queue size */
 	while ((atomic_read(&st->send_queue_size) > DNET_SEND_WATERMARK_HIGH) && !st->__need_exit) {
 		/* If high watermark is reached we should sleep */
-		dnet_log(st->n, DNET_LOG_ERROR,
-				"State high_watermark reached: %s: %ld, sleeping",
+		dnet_log(st->n, DNET_LOG_NOTICE,
+				"State high_watermark reached by iterator: %s: %ld, sleeping",
 				dnet_addr_string(&st->addr),
 				atomic_read(&st->send_queue_size));
 
@@ -331,7 +331,7 @@ static void dnet_queue_wait_threshold(struct dnet_net_state *st)
 			pthread_cond_wait(&st->send_wait, &st->send_lock);
 		pthread_mutex_unlock(&st->send_lock);
 
-		dnet_log(st->n, DNET_LOG_ERROR, "State woken up: %s: %ld",
+		dnet_log(st->n, DNET_LOG_NOTICE, "State woken up, iterator will continue: %s: %ld",
 				dnet_addr_string(&st->addr),
 				atomic_read(&st->send_queue_size));
 	}

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -513,6 +513,15 @@ err_out_send:
 				 * Maximum number of bytes written into the wire and not yet acknowledged.
 				 * It is equal to 'current speed' times 5 seconds, since 5 seconds is default wait timeout
 				 * for write command.
+				 *
+				 * This '5 seconds' rule could be extended to 60 seconds or million of seconds,
+				 * but practice shows that 60 seconds of data at the current speed overflows pipe
+				 * if remote backend starts to slow down.
+				 *
+				 * '5 seconds' is quite enough to fill 1gbit pipe.
+				 *
+				 * Write command timeout has been increased to 60 seconds to cover this 5 seconds of in-flight
+				 * transactions.
 				 */
 				new_pending = 5 * re->size * 1000000 / usec;
 			}

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -749,6 +749,8 @@ int dnet_server_send_write(struct dnet_server_send_ctl *send,
 
 	dnet_session_set_trace_id(s, send->cmd.trace_id);
 	dnet_session_set_trace_bit(s, !!(send->cmd.flags & DNET_FLAGS_TRACE_BIT));
+	if (dnet_session_get_timeout(s)->tv_sec < 60)
+		dnet_session_set_timeout(s, 60);
 
 	err = dnet_session_set_groups(s, send->groups, send->group_num);
 	if (err) {

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -763,14 +763,15 @@ int dnet_server_send_write(struct dnet_server_send_ctl *send,
 	atomic_add(&send->bytes_pending, re->size);
 
 	dnet_log(n, DNET_LOG_INFO, "%s: %s: sending WRITE request, iterator response: %s, user_flags: %llx, ts: %s (%lld.%09lld), "
-			"status: %d, size: %lld, iterated_keys: %lld/%lld",
+			"status: %d, size: %lld, iterated_keys: %lld/%lld, pending_bytes: %ld, limit: %ld",
 			__func__,
 			dnet_dump_id(&send->cmd.id), dnet_dump_id_str(re->key.id),
 			(unsigned long long)re->user_flags,
 			dnet_print_time(&re->timestamp),
 			(unsigned long long)re->timestamp.tsec, (unsigned long long)re->timestamp.tnsec,
 			re->status, (unsigned long long)re->size,
-			(unsigned long long)re->iterated_keys, (unsigned long long)re->total_keys);
+			(unsigned long long)re->iterated_keys, (unsigned long long)re->total_keys,
+			atomic_read(&send->bytes_pending), send->bytes_pending_max);
 
 	/*
 	 * After calling this function we do not own @wp anymore

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -1035,8 +1035,7 @@ again:
 /*
  * Watermarks for number of bytes written into the wire
  */
-#define DNET_SERVER_SEND_WATERMARK_HIGH		(30*1024*1024*1024L)
-#define DNET_SERVER_SEND_WATERMARK_LOW		DNET_SERVER_SEND_WATERMARK_HIGH / 2
+#define DNET_SERVER_SEND_WATERMARK_HIGH		(100*1024*1024L)
 
 /*
  * Send data over network to another server as set of WRITE commands
@@ -1054,10 +1053,12 @@ struct dnet_server_send_ctl {
 
 	pthread_mutex_t			write_lock;	/* Lock for @write_wait */
 	pthread_cond_t			write_wait;	/* Waiting for pending writes */
+	long				bytes_pending_max;	/* maximum size of the 'queue' of write requests */
 	atomic_t			bytes_pending;	/* Number of bytes in-flight to remote servers */
 
 	int				write_error;	/* Set to the first error occurred during write
 							 * This will stop iterator. */
+
 
 	atomic_t			refcnt;		/* Reference counter which will be increased for every
 							 * async WRITE operation. get/put methods should be used


### PR DESCRIPTION
Implemented dynamic queue size for copy/move iterator.
Instead of hardcoded (30G previously) value maximum number of bytes written and not yet acknowledged is calculated dynamically based on time every write request took to complete.
Queue size equals to 5 seconds of data written into the wire at the speed of the just finished write request. 5 seconds has been selected as it equals to default operation timeout.

This pull requests passes all tests, but also passes real-life multi-terabyte tests, which previously failed to complete with slow 'destination' disks.