### PR TITLE
Fixed cache timestamp overwrite

### DIFF
--- a/indexes/local_session.cpp
+++ b/indexes/local_session.cpp
@@ -185,7 +185,8 @@ int local_session::write(const dnet_id &id, const char *data, size_t size, uint6
 	io.user_flags = user_flags;
 	io.timestamp = timestamp;
 
-	dnet_current_time(&io.timestamp);
+	if (dnet_time_is_empty(&io.timestamp))
+		dnet_current_time(&io.timestamp);
 
 	data_buffer buffer(sizeof(dnet_io_attr) + size);
 	buffer.write(io);


### PR DESCRIPTION
Cache sync overwrites user's timestamp, this pull request fixes that.


local_session: do not overwrite valid user's timestamp with current time
tests: added test which writes data into cache with small lifetime/sync timeout, previously cache overwrote user's timestamp with current time, this test checks that timestamp is still valid