### PR TITLE
fixed build

### DIFF
--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -1389,7 +1389,6 @@ static enum dnet_log_level convert_to_dnet_log(int level)
 	case EBLOB_LOG_NOTICE:
 		return DNET_LOG_NOTICE;
 	case EBLOB_LOG_DEBUG:
-	case EBLOB_LOG_SPAM:
 		return DNET_LOG_DEBUG;
 	}
 }


### PR DESCRIPTION
Removed `EBLOB_LOG_SPAM` from the switch because after
https://github.com/reverbrain/eblob/commit/f67a96f7d8e587830b6182466341cbe0815b9a82 it is equal to
`EBLOB_LOG_DEBUG`.