### PR TITLE
trans: fixed race between timeout scanning thread and completion callback

### DIFF
--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -737,6 +737,7 @@ static inline void dnet_counter_set(struct dnet_node *n, int counter, int err, i
 struct dnet_trans;
 int __attribute__((weak)) dnet_process_cmd_raw(struct dnet_backend_io *backend, struct dnet_net_state *st, struct dnet_cmd *cmd, void *data, int recursive);
 int dnet_process_recv(struct dnet_backend_io *backend, struct dnet_net_state *st, struct dnet_io_req *r);
+void dnet_trans_update_timestamp(struct dnet_net_state *st, struct dnet_trans *t);
 
 int dnet_recv(struct dnet_net_state *st, void *data, unsigned int size);
 int dnet_sendfile(struct dnet_net_state *st, int fd, uint64_t *offset, uint64_t size);

--- a/library/net.c
+++ b/library/net.c
@@ -396,7 +396,7 @@ ssize_t dnet_send_fd(struct dnet_net_state *st, void *header, uint64_t hsize,
 	return dnet_io_req_queue(st, &r);
 }
 
-static void dnet_trans_update_timestamp(struct dnet_net_state *st, struct dnet_trans *t)
+void dnet_trans_update_timestamp(struct dnet_net_state *st, struct dnet_trans *t)
 {
 	struct timespec *wait_ts = t->wait_ts.tv_sec ? &t->wait_ts : &st->n->wait_ts;
 
@@ -661,8 +661,6 @@ int dnet_process_recv(struct dnet_backend_io *backend, struct dnet_net_state *st
 		if (t) {
 			if (!(flags & DNET_FLAGS_MORE)) {
 				dnet_trans_remove_nolock(st, t);
-			} else {
-				dnet_trans_update_timestamp(st, t);
 			}
 
 			/*

--- a/library/net.c
+++ b/library/net.c
@@ -713,6 +713,7 @@ int dnet_process_recv(struct dnet_backend_io *backend, struct dnet_net_state *st
 			 */
 
 			pthread_mutex_lock(&st->trans_lock);
+			dnet_trans_update_timestamp(st, t);
 			dnet_trans_insert_timer_nolock(st, t);
 			pthread_mutex_unlock(&st->trans_lock);
 		}

--- a/library/pool.c
+++ b/library/pool.c
@@ -895,7 +895,7 @@ static void *dnet_io_process_network(void *data_)
 				++tmp;
 				err = dnet_state_accept_process(st, &evs[i]);
 			} else if ((evs[i].events & EPOLLOUT) || dnet_check_io(n->io)) {
-				// if event is send or io pool queues are not full then process it
+				// if this is sending event or io pool queues are not full then process it
 				++tmp;
 				err = dnet_state_net_process(st, &evs[i]);
 			} else {

--- a/library/pool.c
+++ b/library/pool.c
@@ -898,9 +898,9 @@ static void *dnet_io_process_network(void *data_)
 				// if event is send or io pool queues are not full then process it
 				++tmp;
 				err = dnet_state_net_process(st, &evs[i]);
-			}
-			else
+			} else {
 				continue;
+			}
 
 			if (err == 0)
 				continue;
@@ -933,10 +933,10 @@ static void *dnet_io_process_network(void *data_)
 			}
 		}
 
-		// wait condition variable if no data was sended and io pool queues are still full
+		// wait condition variable if no data has been sent and io pool queues are still full
 		if (tmp == 0 && dnet_check_io(n->io) == 0) {
 			gettimeofday(&curr_tv, NULL);
-			// print log only if previous log was writed more then 1 seconds
+			// print log only if previous log was written more then 1 seconds ago
 			if ((curr_tv.tv_sec - prev_tv.tv_sec) > 1) {
 				dnet_log(n, DNET_LOG_INFO, "Net pool is suspended bacause io pool queues is full");
 				prev_tv = curr_tv;

--- a/library/pool.c
+++ b/library/pool.c
@@ -266,8 +266,13 @@ static void dnet_update_trans_timestamp_network(struct dnet_io_req *r)
 		t = dnet_trans_search(st, cmd->trans);
 		if (t) {
 			dnet_trans_update_timestamp(st, t);
+
+			/*
+			 * Always remove transaction from 'timer' tree,
+			 * thus it will not be found by checker thread and
+			 * its callback will not be called under us.
+			 */
 			dnet_trans_remove_timer_nolock(st, t);
-			dnet_trans_insert_timer_nolock(st, t);
 		}
 		pthread_mutex_unlock(&st->trans_lock);
 


### PR DESCRIPTION
The latter does not remove transaction from the timer tree and transaction may be grabbed and freed by timeout checking thread.