### PR TITLE
fixed build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends:	cdbs,
 		cmake (>= 2.6),
 		debhelper (>= 7.0.50~),
 		eblob (>= 0.23.11),
-		blackhole-dev (>= 0.2.3-1),
+		blackhole-dev (= 0.2.4-1),
 		libboost-dev,
 		libboost-iostreams-dev,
 		libboost-program-options-dev,
@@ -66,7 +66,7 @@ Description: Distributed hash table storage (debug files)
 
 Package: elliptics-dev
 Architecture: any
-Depends: elliptics-client (= ${Source-Version}), blackhole-dev (>= 0.2.3-1)
+Depends: elliptics-client (= ${Source-Version}), blackhole-dev (= 0.2.4-1)
 Description: Distributed hash table storage (includes)
  Elliptics network is a fault tolerant distributed hash table object storage.
 

--- a/elliptics-bf.spec
+++ b/elliptics-bf.spec
@@ -16,7 +16,7 @@ BuildRequires:	python-devel
 BuildRequires:	libcocaine-core2-devel >= 0.11.2.0
 BuildRequires:  cocaine-framework-native-devel >= 0.11.0.0
 BuildRequires:	eblob-devel >= 0.23.11
-BuildRequires:  libblackhole-devel >= 0.2.3-1
+BuildRequires:  libblackhole-devel = 0.2.4-1
 BuildRequires:	libev-devel libtool-ltdl-devel
 BuildRequires:	cmake msgpack-devel python-msgpack
 BuildRequires:	handystats >= 1.10.2
@@ -67,7 +67,7 @@ cocaine-plugin-elliptics
 Summary:	Elliptics library C++ binding development headers and libraries
 Group:		Development/Libraries
 Requires:	%{name} = %{version}-%{release}
-Requires:   libblackhole-devel >= 0.2.3
+Requires:   libblackhole-devel = 0.2.4-1
 
 
 %description client-devel


### PR DESCRIPTION
Use `blackhole-dev (= 0.2.3-1)` in dependencies because new blackhole v1 has the same name of dev package.