### PR TITLE
Logs

### DIFF
--- a/bindings/cpp/callback.cpp
+++ b/bindings/cpp/callback.cpp
@@ -47,9 +47,9 @@ public:
 		}
 
 		BH_LOG(m_logger, cmd->status ? DNET_LOG_ERROR : DNET_LOG_NOTICE,
-			"%s: handled reply from: %s, cmd: %s, flags: %s, trans: %lld, status: %d, size: %lld, client: %d, last: %d",
-			dnet_dump_id(&cmd->id), addr ? dnet_addr_string(addr) : "<unknown>", dnet_cmd_string(cmd->cmd),
-			dnet_flags_dump_cflags(cmd->flags), uint64_t(cmd->trans), int(cmd->status), uint64_t(cmd->size),
+			"%s: %s: handled reply from: %s, trans: %lld, cflags: %s, status: %d, size: %lld, client: %d, last: %d",
+			dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), addr ? dnet_addr_string(addr) : "<unknown>",
+			uint64_t(cmd->trans), dnet_flags_dump_cflags(cmd->flags), int(cmd->status), uint64_t(cmd->size),
 			!(cmd->flags & DNET_FLAGS_REPLY), !(cmd->flags & DNET_FLAGS_MORE));
 
 		auto data = std::make_shared<callback_result_data>(addr, cmd);

--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -196,9 +196,8 @@ static int blob_write(struct eblob_backend_config *c, void *state,
 	static const size_t ehdr_size = sizeof(struct dnet_ext_list_hdr);
 	int err;
 
-	dnet_backend_log(c->blog, DNET_LOG_NOTICE, "%s: EBLOB: blob-write: WRITE: start: offset: %llu, size: %llu, ioflags: %s",
-		dnet_dump_id_str(io->id), (unsigned long long)io->offset, (unsigned long long)io->size,
-		dnet_flags_dump_ioflags(io->flags));
+	dnet_backend_log(c->blog, DNET_LOG_NOTICE, "%s: EBLOB: blob-write: WRITE: start: %s",
+		dnet_dump_id_str(io->id), dnet_print_io(io));
 
 	dnet_convert_io_attr(io);
 

--- a/example/notify.cpp
+++ b/example/notify.cpp
@@ -67,11 +67,9 @@ static int notify_complete(struct dnet_addr *addr __unused,
 
 	dnet_convert_io_notification(io);
 
-	fprintf(stream, "%s: client: %s, size: %llu, offset: %llu, flags: %s\n",
+	fprintf(stream, "%s: client: %s, %s\n",
 			dnet_dump_id_str(io->io.id), dnet_addr_string(&io->addr),
-			(unsigned long long)io->io.size,
-			(unsigned long long)io->io.offset,
-			dnet_flags_dump_ioflags(io->io.flags));
+			dnet_print_io(&io->io));
 	fflush(stream);
 
 	return 0;

--- a/include/elliptics/interface.h
+++ b/include/elliptics/interface.h
@@ -950,6 +950,23 @@ int dnet_server_send_write(struct dnet_server_send_ctl *send,
 		struct dnet_iterator_response *re, uint64_t dsize,
 		int fd, uint64_t data_offset);
 
+static inline const char *dnet_print_io(const struct dnet_io_attr *io) {
+	static __thread char __dnet_print_io[256];
+	snprintf(__dnet_print_io, sizeof(__dnet_print_io),
+	         "io-flags: %s, "
+	         "io-offset: %llu, "
+	         "io-size: %llu/%llu, "
+	         "io-user-flags: 0x%llx, "
+	         "io-num: %llu, "
+	         "ts: '%s'",
+	         dnet_flags_dump_ioflags(io->flags),
+	         (unsigned long long)io->offset,
+	         (unsigned long long)io->size, (unsigned long long)io->total_size,
+	         (unsigned long long)io->user_flags,
+	         (unsigned long long)io->num,
+	         dnet_print_time(&io->timestamp));
+	return __dnet_print_io;
+}
 
 #ifdef __cplusplus
 }

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -266,9 +266,9 @@ int dnet_send_ack(struct dnet_net_state *st, struct dnet_cmd *cmd, int err, int 
 		ack.flags |= DNET_FLAGS_REPLY;
 		ack.status = err;
 
-		dnet_log(n, DNET_LOG_NOTICE, "%s: %s: ack -> %s: trans: %llu, flags: %s, status: %d.",
-				dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), dnet_addr_string(&st->addr),
-				tid, dnet_flags_dump_cflags(ack.flags), err);
+		dnet_log(n, DNET_LOG_NOTICE, "%s: %s: ack trans: %llu -> %s: cflags: %s, status: %d.",
+				dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), tid,
+				dnet_addr_string(&st->addr), dnet_flags_dump_cflags(ack.flags), err);
 
 		dnet_convert_cmd(&ack);
 		err = dnet_send(st, &ack, sizeof(struct dnet_cmd));
@@ -301,9 +301,9 @@ int dnet_send_reply(void *state, struct dnet_cmd *cmd, const void *odata, unsign
 	if (size)
 		memcpy(data, odata, size);
 
-	dnet_log(st->n, DNET_LOG_NOTICE, "%s: %s: reply -> %s (%p): trans: %lld, size: %u, cflags: %s",
-		dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), dnet_state_dump_addr(st), st,
-		(unsigned long long)c->trans,
+	dnet_log(st->n, DNET_LOG_NOTICE, "%s: %s: reply trans: %lld -> %s (%p): size: %u, cflags: %s",
+		dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), (unsigned long long)c->trans,
+		dnet_state_dump_addr(st), st,
 		size, dnet_flags_dump_cflags(c->flags));
 
 	dnet_convert_cmd(c);
@@ -1689,10 +1689,6 @@ int dnet_process_cmd_raw(struct dnet_backend_io *backend, struct dnet_net_state 
 	}
 
 	if (((cmd->cmd == DNET_CMD_READ) || (cmd->cmd == DNET_CMD_WRITE)) && io) {
-		char time_str[64];
-		struct tm io_tm;
-		struct timeval io_tv;
-
 		/* io has been already set in the switch above */
 
 		// do not count error read size
@@ -1701,22 +1697,11 @@ int dnet_process_cmd_raw(struct dnet_backend_io *backend, struct dnet_net_state 
 		if (cmd->cmd == DNET_CMD_READ && err < 0)
 			iosize = 0;
 
-		io_tv.tv_sec = io->timestamp.tsec;
-		io_tv.tv_usec = io->timestamp.tnsec / 1000;
-
-		localtime_r((time_t *)&io_tv.tv_sec, &io_tm);
-		strftime(time_str, sizeof(time_str), "%F %R:%S", &io_tm);
-
-		dnet_log(n, DNET_LOG_INFO, "%s: %s: client: %s, trans: %llu, cflags: %s, "
-				"ioflags: %s, io-offset: %llu, io-size: %llu/%llu, io-user-flags: 0x%llx, "
-				"ts: %ld.%06ld '%s.%06lu', "
+		dnet_log(n, DNET_LOG_INFO, "%s: %s: client: %s, trans: %llu, cflags: %s, %s, "
 				"time: %ld usecs, err: %d.",
 				dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), dnet_state_dump_addr(st),
 				tid, dnet_flags_dump_cflags(cmd->flags),
-				dnet_flags_dump_ioflags(io->flags),
-				(unsigned long long)io->offset, (unsigned long long)io->size, (unsigned long long)io->total_size,
-				(unsigned long long)io->user_flags,
-				io_tv.tv_sec, io_tv.tv_usec, time_str, io_tv.tv_usec,
+				dnet_print_io(io),
 				diff, err);
 	} else {
 		dnet_log(n, DNET_LOG_INFO, "%s: %s: client: %s, trans: %llu, cflags: %s, time: %ld usecs, err: %d.",
@@ -1811,10 +1796,9 @@ int dnet_send_read_data(void *state, struct dnet_cmd *cmd, struct dnet_io_attr *
 	send_time = DIFF(csum_tv, send_tv);
 	total_time = DIFF(start_tv, send_tv);
 
-	dnet_log(n, DNET_LOG_INFO, "%s: %s: reply: cflags: %s, ioflags: %s, offset: %llu, size: %llu, csum-time: %ld, send-time: %ld, total-time: %ld usecs.",
+	dnet_log(n, DNET_LOG_INFO, "%s: %s: reply: cflags: %s, %s, csum-time: %ld, send-time: %ld, total-time: %ld usecs.",
 			dnet_dump_id(&c->id), dnet_cmd_string(c->cmd),
-			dnet_flags_dump_cflags(cmd->flags), dnet_flags_dump_ioflags(io->flags),
-			(unsigned long long)io->offset,	(unsigned long long)io->size,
+			dnet_flags_dump_cflags(cmd->flags), dnet_print_io(io),
 			csum_time, send_time, total_time);
 
 

--- a/library/dnet_common.c
+++ b/library/dnet_common.c
@@ -390,18 +390,14 @@ void dnet_io_trans_alloc_send(struct dnet_session *s, struct dnet_io_control *ct
 	dnet_get_backend_weight(t->st, cmd->backend_id, io->flags, &backend_weight);
 	request_addr = dnet_state_addr(t->st);
 
-	dnet_log(n, DNET_LOG_INFO, "%s: created trans: %llu, cmd: %s, cflags: %s, size: %llu, offset: %llu, "
-			"fd: %d, local_offset: %llu -> %s/%d weight: %f, wait-ts: %ld, ioflags: %s, ionum: %llu",
+	dnet_log(n, DNET_LOG_INFO, "%s: %s: created %s, weight: %f, %s, fd: %d, local_offset: %llu",
 			dnet_dump_id(&ctl->id),
-			(unsigned long long)t->trans,
-			dnet_cmd_string(ctl->cmd), dnet_flags_dump_cflags(cmd->flags),
-			(unsigned long long)ctl->io.size, (unsigned long long)ctl->io.offset,
+			dnet_cmd_string(t->cmd.cmd),
+			dnet_print_trans(t),
+			backend_weight,
+			dnet_print_io(&ctl->io),
 			ctl->fd,
-			(unsigned long long)ctl->local_offset,
-		        dnet_addr_string(&t->st->addr), cmd->backend_id, backend_weight,
-			t->wait_ts.tv_sec,
-			dnet_flags_dump_ioflags(ctl->io.flags),
-			(unsigned long long)io->num);
+			(unsigned long long)ctl->local_offset);
 
 	dnet_convert_cmd(cmd);
 	dnet_convert_io_attr(io);

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -1068,6 +1068,17 @@ struct dnet_server_send_ctl {
 							 */
 };
 
+static inline const char* dnet_print_trans(const struct dnet_trans *t) {
+	static __thread char __dnet_print_trans[256];
+	snprintf(__dnet_print_trans, sizeof(__dnet_print_trans),
+	         "trans: %llu, st: %s/%d, cflags: %s, wait-ts: %ld",
+	         (unsigned long long)t->trans,
+	         dnet_state_dump_addr(t->st), t->cmd.backend_id,
+	         dnet_flags_dump_cflags(t->cmd.flags),
+	         t->wait_ts.tv_sec);
+	return __dnet_print_trans;
+}
+
 
 #ifdef __cplusplus
 }

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -162,7 +162,7 @@ struct dnet_net_state
 	// Mapping backend_id -> struct dnet_idc
 	struct rb_root		idc_root;
 	// idc_lock is guard of idc_root structure, not values of idc_root items
-	pthread_rwlock_t        idc_lock;
+	pthread_rwlock_t	idc_lock;
 
 	struct dnet_node	*n;
 
@@ -991,16 +991,16 @@ static inline void dnet_version_decode(struct dnet_id *id, int version[4])
 
 static inline void dnet_indexes_shard_count_encode(struct dnet_id *id, int count)
 {
-    int *data = (int *)(id->id);
+	int *data = (int *)(id->id);
 
-    data[5] = dnet_bswap32(count);
+	data[5] = dnet_bswap32(count);
 }
 
 static inline void dnet_indexes_shard_count_decode(struct dnet_id *id, int *count)
 {
-    int *data = (int *)(id->id);
+	int *data = (int *)(id->id);
 
-    *count = dnet_bswap32(data[5]);
+	*count = dnet_bswap32(data[5]);
 }
 
 static inline int dnet_empty_addr(struct dnet_addr *addr)
@@ -1049,7 +1049,7 @@ struct dnet_server_send_ctl {
 
 	uint64_t			iflags;		/* Iterator flags */
 
-	int                             backend_id;     /* Source backend_id */
+	int				backend_id;	/* Source backend_id */
 	int				*groups;	/* Groups to send WRITE commands */
 	int				group_num;
 

--- a/library/net.c
+++ b/library/net.c
@@ -1293,7 +1293,7 @@ int dnet_send_request(struct dnet_net_state *st, struct dnet_io_req *r)
 	int cork;
 	int err = 0;
 	size_t offset = st->send_offset;
-	size_t total_size = r->dsize + r->hsize + r->fsize;
+	const size_t total_size = r->dsize + r->hsize + r->fsize;
 
 	if (total_size > sizeof(struct dnet_cmd)) {
 		/* Use TCP_CORK to send headers and packet body in one piece */
@@ -1302,15 +1302,14 @@ int dnet_send_request(struct dnet_net_state *st, struct dnet_io_req *r)
 	}
 
 	if (1) {
-		struct dnet_cmd *cmd = r->header;
-		if (!cmd)
-			cmd = r->data;
+		struct dnet_cmd *cmd = r->header ? r->header : r->data;
 		dnet_node_set_trace_id(st->n->log, cmd->trace_id, cmd->flags & DNET_FLAGS_TRACE_BIT, (ssize_t)-1);
-		dnet_log(st->n, DNET_LOG_DEBUG, "%s: %s: sending -> %s: trans: %lld, size: %llu, cflags: %s, start-sent: %zd/%zd.",
-			dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), dnet_addr_string(&st->addr),
-			(unsigned long long)cmd->trans,
+		dnet_log(st->n, st->send_offset == 0 ? DNET_LOG_INFO : DNET_LOG_DEBUG,
+			"%s: %s: sending trans: %lld -> %s/%d: size: %llu, cflags: %s, start-sent: %zd/%zd",
+			dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), (unsigned long long)cmd->trans,
+			dnet_addr_string(&st->addr), cmd->backend_id,
 			(unsigned long long)cmd->size, dnet_flags_dump_cflags(cmd->flags),
-			st->send_offset, r->dsize + r->hsize + r->fsize);
+			st->send_offset, total_size);
 	}
 
 	if (r->hsize && r->header && st->send_offset < r->hsize) {
@@ -1326,7 +1325,7 @@ int dnet_send_request(struct dnet_net_state *st, struct dnet_io_req *r)
 			goto err_out_exit;
 	}
 
-	if (r->fd >= 0 && r->fsize && st->send_offset < (r->dsize + r->hsize + r->fsize)) {
+	if (r->fd >= 0 && r->fsize && st->send_offset < total_size) {
 		offset = st->send_offset - r->dsize - r->hsize;
 		err = dnet_send_fd_nolock(st, r->fd, r->local_offset + offset, r->fsize - offset);
 		if (err)
@@ -1347,14 +1346,13 @@ int dnet_send_request(struct dnet_net_state *st, struct dnet_io_req *r)
 err_out_exit:
 
 	if (1) {
-		struct dnet_cmd *cmd = r->header;
-		if (!cmd)
-			cmd = r->data;
-		dnet_log(st->n, DNET_LOG_DEBUG, "%s: %s: sending -> %s: trans: %lld, size: %llu, cflags: %s, finish-sent: %zd/%zd.",
-			dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), dnet_addr_string(&st->addr),
-			(unsigned long long)cmd->trans,
+		struct dnet_cmd *cmd = r->header ? r->header : r->data;
+		dnet_log(st->n, st->send_offset == total_size ? DNET_LOG_INFO : DNET_LOG_DEBUG,
+			"%s: %s: sending trans: %lld -> %s/%d: size: %llu, cflags: %s, finish-sent: %zd/%zd",
+			dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), (unsigned long long)cmd->trans,
+			dnet_addr_string(&st->addr), cmd->backend_id,
 			(unsigned long long)cmd->size, dnet_flags_dump_cflags(cmd->flags),
-			st->send_offset, r->dsize + r->hsize + r->fsize);
+			st->send_offset, total_size);
 	}
 	dnet_node_unset_trace_id();
 
@@ -1371,7 +1369,7 @@ err_out_exit:
 	 * or under st->send_lock, if queue was empty and dnet_send*() caller directly invoked this function from dnet_io_req_queue()
 	 * instead of queueing.
 	 */
-	if (st->send_offset == r->dsize + r->hsize + r->fsize) {
+	if (st->send_offset == total_size) {
 		int nodelay = 1;
 		setsockopt(st->write_s, IPPROTO_TCP, TCP_NODELAY, &nodelay, 4);
 	}

--- a/library/net.c
+++ b/library/net.c
@@ -576,7 +576,7 @@ static int dnet_trans_forward(struct dnet_io_req *r,
 		char saddr[128];
 		char daddr[128];
 
-		dnet_log(orig->n, DNET_LOG_INFO, "%s: forwarding %s trans: %s -> %s, trans: %llu -> %llu",
+		dnet_log(orig->n, DNET_LOG_INFO, "%s: %s: forwarding trans: %s -> %s, trans: %llu -> %llu",
 				dnet_dump_id(&t->cmd.id), dnet_cmd_string(t->command),
 				dnet_addr_string_raw(&orig->addr, saddr, sizeof(saddr)),
 				dnet_addr_string_raw(&forward->addr, daddr, sizeof(daddr)),

--- a/library/pool.c
+++ b/library/pool.c
@@ -449,10 +449,10 @@ again:
 
 		tid = c->trans;
 
-		dnet_log(n, DNET_LOG_DEBUG, "%s: received trans: %llu / 0x%llx, "
-				"reply: %d, size: %llu, flags: %s, status: %d.",
-				dnet_dump_id(&c->id), tid, (unsigned long long)c->trans,
-				!!(c->flags & DNET_FLAGS_REPLY),
+		dnet_log(n, DNET_LOG_DEBUG, "%s: %s: received trans: %llu <- %s/%d: "
+				"size: %llu, cflags: %s, status: %d.",
+				dnet_dump_id(&c->id), dnet_cmd_string(c->cmd), tid,
+				dnet_state_dump_addr(st), c->backend_id,
 				(unsigned long long)c->size, dnet_flags_dump_cflags(c->flags), c->status);
 
 		r = malloc(c->size + sizeof(struct dnet_cmd) + sizeof(struct dnet_io_req));
@@ -935,12 +935,12 @@ static void *dnet_io_process_network(void *data_)
 				continue;
 
 			if ((err < 0 && err != -EAGAIN) || st->stall >= n->stall_count) {
-				char addr_str[128] = "no address";
+				char addr_str[128] = "<unknown>";
 				if (n->addr_num) {
 					dnet_addr_string_raw(&n->addrs[0], addr_str, sizeof(addr_str));
 				}
-				dnet_log(n, DNET_LOG_ERROR, "self: addr: %s, resetting state: %p", addr_str, st);
-				dnet_log(n, DNET_LOG_ERROR, "self: addr: %s, resetting state: %s", addr_str, dnet_state_dump_addr(st));
+				dnet_log(n, DNET_LOG_ERROR, "self: addr: %s, resetting state: %s (%p)",
+				         addr_str, dnet_state_dump_addr(st), st);
 
 				dnet_state_reset(st, err);
 
@@ -967,7 +967,7 @@ static void *dnet_io_process_network(void *data_)
 			gettimeofday(&curr_tv, NULL);
 			// print log only if previous log was written more then 1 seconds ago
 			if ((curr_tv.tv_sec - prev_tv.tv_sec) > 1) {
-				dnet_log(n, DNET_LOG_INFO, "Net pool is suspended bacause io pool queues is full");
+				dnet_log(n, DNET_LOG_INFO, "Net pool is suspended because io pool queues is full");
 				prev_tv = curr_tv;
 			}
 			// wait condition variable - io queues has a free slot or some socket has something to send


### PR DESCRIPTION
I've structured logs connected with sending and handling requests in common format:
`[id]: [command string]: [action message] [transaction attributes] [other attributes]` - make it easier to view and analyze requests' logs.

Level of first start-sent and last finish-sent log message is changed to `DNET_LOG_INFO` - it allows to analyze on info level when request/response sending process starts and finishes.

I've eliminated handling lookups by cache when cache does not have requested key - avoid sending another lookup by cache directly to the backend.