### PR TITLE
Update backend weight calculation

### DIFF
--- a/include/elliptics/packet.h
+++ b/include/elliptics/packet.h
@@ -38,7 +38,7 @@ extern "C" {
 #endif
 
 /*
- * Header note fpr @dnet_commands enum
+ * Header note for @dnet_commands enum
  * When adding new command, take a look at @dnet_cmd_needs_backend(),
  * it must be updated if new non-backend command is added.
  */
@@ -54,7 +54,7 @@ enum dnet_commands {
 						 * IO attribute which will have offset and size
 						 * parameters.
 						 */
-	DNET_CMD_LIST_DEPRECATED,		/* List all objects for given node ID. Deperacted and forbidden */
+	DNET_CMD_LIST_DEPRECATED,		/* List all objects for given node ID. Deprecated and forbidden */
 	DNET_CMD_EXEC,				/* Execute given command on the remote node */
 	DNET_CMD_ROUTE_LIST,			/* Receive route table from given node */
 	DNET_CMD_STAT_DEPRECATED,		/* Gather remote VM, LA and FS statistics */
@@ -64,7 +64,7 @@ enum dnet_commands {
 	DNET_CMD_STATUS,			/* Change elliptics node status */
 	DNET_CMD_READ_RANGE,			/* Read range of objects */
 	DNET_CMD_DEL_RANGE,			/* Remove range of objects */
-	DNET_CMD_AUTH,				/* Authentification cookie check */
+	DNET_CMD_AUTH,				/* Authentication cookie check */
 	DNET_CMD_BULK_READ,			/* Read a number of ids at one time */
 	DNET_CMD_DEFRAG_DEPRECATED,		/* Start defragmentation process if backend supports it. Deprecated and forbidden */
 	DNET_CMD_ITERATOR,			/* Start/stop/pause/status for server-side iterator */
@@ -155,7 +155,7 @@ enum dnet_backend_defrag_level {
 /* Transaction is about to be destroyed */
 #define DNET_FLAGS_DESTROY		(1<<2)
 
-/* Do not forward requst to antoher node even if given ID does not belong to our range */
+/* Do not forward request to another node even if given ID does not belong to our range */
 #define DNET_FLAGS_DIRECT		(1<<3)
 
 /* Do not locks operations - must be set for script callers or recursive operations */

--- a/library/dnet_common.c
+++ b/library/dnet_common.c
@@ -367,7 +367,10 @@ void dnet_io_trans_alloc_send(struct dnet_session *s, struct dnet_io_control *ct
 	memcpy(io, &ctl->io, sizeof(struct dnet_io_attr));
 
 	if ((s->cflags & DNET_FLAGS_DIRECT) == 0) {
-		t->st = dnet_state_get_first(n, &cmd->id);
+		int backend_id = 0;
+		t->st = dnet_state_get_first_with_backend(n, &cmd->id, &backend_id);
+		if (!(s->cflags & DNET_FLAGS_DIRECT_BACKEND))
+			cmd->backend_id = backend_id;
 	} else {
 		/* We're requested to execute request on particular node */
 		request_addr = &s->direct_addr;

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -269,8 +269,7 @@ struct dnet_net_state *dnet_state_get_first(struct dnet_node *n, const struct dn
 ssize_t dnet_state_search_backend(struct dnet_node *n, const struct dnet_id *id);
 int dnet_get_backend_weight(struct dnet_net_state *st, int backend_id, uint32_t ioflags, double *weight);
 void dnet_set_backend_weight(struct dnet_net_state *st, int backend_id, uint32_t ioflags, double weight);
-void dnet_update_backend_weight(struct dnet_net_state *st, int backend_id,
-                                int status, uint64_t ioflags, uint64_t size, long time);
+void dnet_update_backend_weight(struct dnet_net_state *st, const struct dnet_cmd *, uint64_t ioflags, long time);
 struct dnet_net_state *dnet_state_search_nolock(struct dnet_node *n, const struct dnet_id *id, int *backend_id);
 struct dnet_net_state *dnet_node_state(struct dnet_node *n);
 

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -269,6 +269,8 @@ struct dnet_net_state *dnet_state_get_first(struct dnet_node *n, const struct dn
 ssize_t dnet_state_search_backend(struct dnet_node *n, const struct dnet_id *id);
 int dnet_get_backend_weight(struct dnet_net_state *st, int backend_id, uint32_t ioflags, double *weight);
 void dnet_set_backend_weight(struct dnet_net_state *st, int backend_id, uint32_t ioflags, double weight);
+void dnet_update_backend_weight(struct dnet_net_state *st, int backend_id,
+                                int status, uint64_t ioflags, uint64_t size, long time);
 struct dnet_net_state *dnet_state_search_nolock(struct dnet_node *n, const struct dnet_id *id, int *backend_id);
 struct dnet_net_state *dnet_node_state(struct dnet_node *n);
 

--- a/library/net.c
+++ b/library/net.c
@@ -653,8 +653,6 @@ int dnet_process_recv(struct dnet_backend_io *backend, struct dnet_net_state *st
 		struct dnet_trans *t = NULL;
 		uint64_t tid = cmd->trans;
 		uint64_t flags = cmd->flags;
-		struct timeval tv;
-		long diff;
 
 		HANDY_COUNTER_INCREMENT("io.replies", 1);
 
@@ -688,11 +686,9 @@ int dnet_process_recv(struct dnet_backend_io *backend, struct dnet_net_state *st
 			goto err_out_exit;
 		}
 
-		gettimeofday(&tv, NULL);
-		diff = (tv.tv_sec - t->start.tv_sec) * 1000000 + (tv.tv_usec - t->start.tv_usec);
-
 		if (t->complete) {
 			if (t->command == DNET_CMD_READ) {
+				uint64_t ioflags = 0;
 				if ((cmd->size >= sizeof(struct dnet_io_attr)) &&
 						(t->alloc_size >= sizeof(struct dnet_cmd) + sizeof(struct dnet_io_attr))) {
 					struct dnet_io_attr *recv_io = (struct dnet_io_attr *)(cmd + 1);
@@ -700,7 +696,7 @@ int dnet_process_recv(struct dnet_backend_io *backend, struct dnet_net_state *st
 					struct dnet_cmd *local_cmd = (struct dnet_cmd *)(t + 1);
 					struct dnet_io_attr *local_io = (struct dnet_io_attr *)(local_cmd + 1);
 
-					local_io->flags = recv_io->flags;
+					ioflags = local_io->flags = recv_io->flags;
 					local_io->size = recv_io->size;
 					local_io->offset = recv_io->offset;
 					local_io->user_flags = recv_io->user_flags;
@@ -708,10 +704,16 @@ int dnet_process_recv(struct dnet_backend_io *backend, struct dnet_net_state *st
 					local_io->timestamp = recv_io->timestamp;
 
 					dnet_convert_io_attr(local_io);
+				}
 
-					if (st && !(flags & DNET_FLAGS_MORE)) {
-						dnet_update_backend_weight(st, cmd, recv_io->flags, diff);
-					}
+				if (st && !(flags & DNET_FLAGS_MORE)) {
+					struct timeval tv;
+					long diff;
+
+					gettimeofday(&tv, NULL);
+					diff = (tv.tv_sec - t->start.tv_sec) * 1000000 + (tv.tv_usec - t->start.tv_usec);
+
+					dnet_update_backend_weight(st, cmd, ioflags, diff);
 				}
 			}
 			t->complete(dnet_state_addr(t->st), cmd, t->priv);

--- a/library/net.c
+++ b/library/net.c
@@ -710,8 +710,7 @@ int dnet_process_recv(struct dnet_backend_io *backend, struct dnet_net_state *st
 					dnet_convert_io_attr(local_io);
 
 					if (st && !(flags & DNET_FLAGS_MORE)) {
-						dnet_update_backend_weight(st, cmd->backend_id,
-						                           cmd->status, recv_io->flags, cmd->size, diff);
+						dnet_update_backend_weight(st, cmd, recv_io->flags, diff);
 					}
 				}
 			}

--- a/library/net.c
+++ b/library/net.c
@@ -711,7 +711,7 @@ int dnet_process_recv(struct dnet_backend_io *backend, struct dnet_net_state *st
 
 					if (st && !(flags & DNET_FLAGS_MORE)) {
 						dnet_update_backend_weight(st, cmd->backend_id,
-						                           cmd->status, recv_io->flags, local_io->size, diff);
+						                           cmd->status, recv_io->flags, cmd->size, diff);
 					}
 				}
 			}

--- a/library/node.c
+++ b/library/node.c
@@ -660,8 +660,6 @@ void dnet_update_backend_weight(struct dnet_net_state *st, const struct dnet_cmd
 		const double norm = (double)time / (double) cmd->size;
 		new_weight = 1.0 / ((1.0 / old_weight + norm) / 2.0);
 		dnet_set_backend_weight(st, cmd->backend_id, ioflags, new_weight);
-	} else {
-		new_weight = old_weight;
 	}
 	return err;
 }

--- a/library/node.c
+++ b/library/node.c
@@ -648,6 +648,25 @@ void dnet_set_backend_weight(struct dnet_net_state *st, int backend_id, uint32_t
 	pthread_rwlock_unlock(&st->idc_lock);
 }
 
+void dnet_update_backend_weight(struct dnet_net_state *st, int backend_id,
+                                int status, uint64_t ioflags, uint64_t size, long time) {
+	double old_weight = 0., new_weight = 0.;
+	if (!st)
+		return;
+
+	const err = dnet_get_backend_weight(st, backend_id, ioflags, &old_weight);
+	if (!err &&
+	    status == 0 &&
+	    size) {
+		const double norm = (double)time / (double) size;
+		new_weight = 1.0 / ((1.0 / old_weight + norm) / 2.0);
+		dnet_set_backend_weight(st, backend_id, ioflags, new_weight);
+	} else {
+		new_weight = old_weight;
+	}
+	return err;
+}
+
 struct dnet_net_state *dnet_state_get_first_with_backend(struct dnet_node *n, const struct dnet_id *id, int *backend_id)
 {
 	struct dnet_net_state *found;

--- a/library/node.c
+++ b/library/node.c
@@ -648,19 +648,18 @@ void dnet_set_backend_weight(struct dnet_net_state *st, int backend_id, uint32_t
 	pthread_rwlock_unlock(&st->idc_lock);
 }
 
-void dnet_update_backend_weight(struct dnet_net_state *st, int backend_id,
-                                int status, uint64_t ioflags, uint64_t size, long time) {
+void dnet_update_backend_weight(struct dnet_net_state *st, const struct dnet_cmd *cmd, uint64_t ioflags, long time) {
 	double old_weight = 0., new_weight = 0.;
 	if (!st)
 		return;
 
-	const err = dnet_get_backend_weight(st, backend_id, ioflags, &old_weight);
+	const err = dnet_get_backend_weight(st, cmd->backend_id, ioflags, &old_weight);
 	if (!err &&
-	    status == 0 &&
-	    size) {
-		const double norm = (double)time / (double) size;
+	    cmd->status == 0 &&
+	    cmd->size) {
+		const double norm = (double)time / (double) cmd->size;
 		new_weight = 1.0 / ((1.0 / old_weight + norm) / 2.0);
-		dnet_set_backend_weight(st, backend_id, ioflags, new_weight);
+		dnet_set_backend_weight(st, cmd->backend_id, ioflags, new_weight);
 	} else {
 		new_weight = old_weight;
 	}

--- a/library/trans.c
+++ b/library/trans.c
@@ -286,25 +286,12 @@ void dnet_trans_destroy(struct dnet_trans *t)
 		    (t->alloc_size >= sizeof(struct dnet_cmd) + sizeof(struct dnet_io_attr))) {
 			struct dnet_cmd *local_cmd = (struct dnet_cmd *)(t + 1);
 			struct dnet_io_attr *local_io = (struct dnet_io_attr *)(local_cmd + 1);
-			double old_backend_weight = 0.;
-			double new_backend_weight = 0.;
+			double backend_weight = 0.;
 
-			if (st) {
-				const int err = dnet_get_backend_weight(st, t->cmd.backend_id, local_io->flags, &old_backend_weight);
-				if (!err &&
-				    (t->command == DNET_CMD_READ) &&
-				    (t->cmd.status == 0) &&
-				    local_io->size) {
-					const double norm = (double)diff / (double)local_io->size;
-					new_backend_weight = 1.0 / ((1.0 / old_backend_weight + norm) / 2.0);
-					dnet_set_backend_weight(st, t->cmd.backend_id, local_io->flags, new_backend_weight);
-				} else {
-					new_backend_weight = old_backend_weight;
-				}
-			}
+			dnet_get_backend_weight(st, t->cmd.backend_id, local_io->flags, &backend_weight);
 
-			snprintf(io_buf, sizeof(io_buf), ", weight: %f -> %f, %s",
-				old_backend_weight, new_backend_weight, dnet_print_io(local_io));
+			snprintf(io_buf, sizeof(io_buf), ", weight: %f, %s",
+			         backend_weight, dnet_print_io(local_io));
 		}
 
 		dnet_log(st->n, DNET_LOG_INFO, "%s: %s: destruction %s, stall: %d, "


### PR DESCRIPTION
2 major changes of this PR:

- move backend weight calculation to `dnet_process_recv`. This makes time used in the calculation more correct because now it does not include time spent in user's callbacks.
- use size of whole packet instead of size of read data. Read response packet consists of `[dnet_cmd][dnet_io_attr][read data]`. First two parts have fixed size, so there is no different what to use in weight calculation: size of `read data` or size of whole packet.