### PR TITLE
Server send timeouts extension

### DIFF
--- a/bindings/cpp/session.cpp
+++ b/bindings/cpp/session.cpp
@@ -2310,6 +2310,7 @@ async_iterator_result session::start_copy_iterator(const key &id,
 	req->time_end = time_end;
 	req->range_num = ranges.size();
 	req->group_num = dst_groups.size();
+	req->timeout = get_timeout();
 
 	if (ranges_size)
 		memcpy(data.skip<dnet_iterator_request>().data(), &ranges.front(), ranges_size);
@@ -2453,6 +2454,7 @@ async_iterator_result session::server_send(const std::vector<key> &keys, uint64_
 			req->id_num = ids.size();
 			req->group_num = groups.size();
 			req->iflags = iflags;
+			req->timeout = get_timeout();
 
 			dnet_convert_server_send_request(req);
 

--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -998,11 +998,15 @@ static int blob_send(struct eblob_backend_config *cfg, void *state, struct dnet_
 	cmd->flags |= DNET_FLAGS_NEED_ACK;
 
 	backend_id = cfg->data.stat_id;
-	ctl = dnet_server_send_alloc(state, cmd, req->iflags, groups, req->group_num, backend_id);
+	ctl = dnet_server_send_alloc(state, cmd, groups, req->group_num);
 	if (!ctl) {
 		err = -ENOMEM;
 		goto err_out_exit;
 	}
+
+	ctl->iflags = req->iflags;
+	ctl->backend_id = backend_id;
+	ctl->timeout = req->timeout;
 
 	/*
 	 * Deliberately clear NEED_ACK bit

--- a/include/elliptics/interface.h
+++ b/include/elliptics/interface.h
@@ -942,8 +942,10 @@ struct dnet_vm_stat {
 int dnet_get_vm_stat(dnet_logger *l, struct dnet_vm_stat *st);
 
 struct dnet_server_send_ctl;
-struct dnet_server_send_ctl *dnet_server_send_alloc(void *state, struct dnet_cmd *cmd, uint64_t iflags,
-						    int *groups, int group_num, int backend_id);
+
+// all other fields of @dnet_server_send_ctl must be set manually, no need to increase number of parameters
+// groups are here since they will be allocated as one chunk with control structure itself
+struct dnet_server_send_ctl *dnet_server_send_alloc(void *state, struct dnet_cmd *cmd, int *groups, int group_num);
 struct dnet_server_send_ctl *dnet_server_send_get(struct dnet_server_send_ctl *ctl);
 int dnet_server_send_put(struct dnet_server_send_ctl *ctl);
 int dnet_server_send_write(struct dnet_server_send_ctl *send,

--- a/include/elliptics/packet.h
+++ b/include/elliptics/packet.h
@@ -1091,7 +1091,7 @@ struct dnet_iterator_request
 	uint64_t			flags;		/* DNET_IFLAGS_* */
 	uint32_t			group_num;	/* Number of remote groups to send iterated data for server-send
 							   iterator type */
-	uint32_t			__reserved32;
+	uint32_t			timeout;	/* write session timeout */
 	uint64_t			reserved[4];
 } __attribute__ ((packed));
 
@@ -1103,6 +1103,7 @@ static inline void dnet_convert_iterator_request(struct dnet_iterator_request *r
 	r->action = dnet_bswap32(r->action);
 	r->range_num = dnet_bswap64(r->range_num);
 	r->group_num = dnet_bswap32(r->group_num);
+	r->timeout = dnet_bswap32(r->timeout);
 	dnet_convert_time(&r->time_begin);
 	dnet_convert_time(&r->time_end);
 }
@@ -1243,13 +1244,17 @@ static inline void dnet_convert_monitor_stat_request(struct dnet_monitor_stat_re
 struct dnet_server_send_request {
 	int		id_num;
 	int		group_num;
+	int		timeout;
+	int		__reserved32;
 	uint64_t	iflags;
+	uint64_t	__reserved[9];
 };
 
 static inline void dnet_convert_server_send_request(struct dnet_server_send_request *req)
 {
 	req->id_num = dnet_bswap32(req->id_num);
 	req->group_num = dnet_bswap32(req->group_num);
+	req->timeout = dnet_bswap32(req->timeout);
 	req->iflags = dnet_bswap64(req->iflags);
 }
 

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -738,7 +738,7 @@ static inline void dnet_counter_set(struct dnet_node *n, int counter, int err, i
 struct dnet_trans;
 int __attribute__((weak)) dnet_process_cmd_raw(struct dnet_backend_io *backend, struct dnet_net_state *st, struct dnet_cmd *cmd, void *data, int recursive);
 int dnet_process_recv(struct dnet_backend_io *backend, struct dnet_net_state *st, struct dnet_io_req *r);
-void dnet_trans_update_timestamp(struct dnet_net_state *st, struct dnet_trans *t);
+void dnet_trans_update_timestamp(struct dnet_trans *t);
 
 int dnet_recv(struct dnet_net_state *st, void *data, unsigned int size);
 int dnet_sendfile(struct dnet_net_state *st, int fd, uint64_t *offset, uint64_t size);

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -1054,6 +1054,8 @@ struct dnet_server_send_ctl {
 	int				*groups;	/* Groups to send WRITE commands */
 	int				group_num;
 
+	int				timeout;	/* write timeout */
+
 	pthread_mutex_t			write_lock;	/* Lock for @write_wait */
 	pthread_cond_t			write_wait;	/* Waiting for pending writes */
 	long				bytes_pending_max;	/* maximum size of the 'queue' of write requests */

--- a/library/net.c
+++ b/library/net.c
@@ -396,14 +396,12 @@ ssize_t dnet_send_fd(struct dnet_net_state *st, void *header, uint64_t hsize,
 	return dnet_io_req_queue(st, &r);
 }
 
-void dnet_trans_update_timestamp(struct dnet_net_state *st, struct dnet_trans *t)
+void dnet_trans_update_timestamp(struct dnet_trans *t)
 {
-	struct timespec *wait_ts = t->wait_ts.tv_sec ? &t->wait_ts : &st->n->wait_ts;
-
 	gettimeofday(&t->time, NULL);
 
-	t->time.tv_sec += wait_ts->tv_sec;
-	t->time.tv_usec += wait_ts->tv_nsec / 1000;
+	t->time.tv_sec += t->wait_ts.tv_sec;
+	t->time.tv_usec += t->wait_ts.tv_nsec / 1000;
 }
 
 int dnet_trans_send(struct dnet_trans *t, struct dnet_io_req *req)
@@ -417,7 +415,7 @@ int dnet_trans_send(struct dnet_trans *t, struct dnet_io_req *req)
 	pthread_mutex_lock(&st->trans_lock);
 	err = dnet_trans_insert_nolock(st, t);
 	if (!err) {
-		dnet_trans_update_timestamp(st, t);
+		dnet_trans_update_timestamp(t);
 		dnet_trans_insert_timer_nolock(st, t);
 	}
 	pthread_mutex_unlock(&st->trans_lock);
@@ -731,7 +729,7 @@ int dnet_process_recv(struct dnet_backend_io *backend, struct dnet_net_state *st
 			 */
 
 			pthread_mutex_lock(&st->trans_lock);
-			dnet_trans_update_timestamp(st, t);
+			dnet_trans_update_timestamp(t);
 			dnet_trans_insert_timer_nolock(st, t);
 			pthread_mutex_unlock(&st->trans_lock);
 		}

--- a/library/node.c
+++ b/library/node.c
@@ -653,7 +653,7 @@ void dnet_update_backend_weight(struct dnet_net_state *st, const struct dnet_cmd
 	if (!st)
 		return;
 
-	const err = dnet_get_backend_weight(st, cmd->backend_id, ioflags, &old_weight);
+	int err = dnet_get_backend_weight(st, cmd->backend_id, ioflags, &old_weight);
 	if (!err &&
 	    cmd->status == 0 &&
 	    cmd->size) {
@@ -661,7 +661,6 @@ void dnet_update_backend_weight(struct dnet_net_state *st, const struct dnet_cmd
 		new_weight = 1.0 / ((1.0 / old_weight + norm) / 2.0);
 		dnet_set_backend_weight(st, cmd->backend_id, ioflags, new_weight);
 	}
-	return err;
 }
 
 struct dnet_net_state *dnet_state_get_first_with_backend(struct dnet_node *n, const struct dnet_id *id, int *backend_id)

--- a/library/pool.c
+++ b/library/pool.c
@@ -265,7 +265,7 @@ static void dnet_update_trans_timestamp_network(struct dnet_io_req *r)
 		pthread_mutex_lock(&st->trans_lock);
 		t = dnet_trans_search(st, cmd->trans);
 		if (t) {
-			dnet_trans_update_timestamp(st, t);
+			dnet_trans_update_timestamp(t);
 
 			/*
 			 * Always remove transaction from 'timer' tree,

--- a/library/trans.c
+++ b/library/trans.c
@@ -221,6 +221,7 @@ struct dnet_trans *dnet_trans_alloc(struct dnet_node *n, uint64_t size)
 
 	t->alloc_size = size;
 	t->n = n;
+	t->wait_ts = n->wait_ts;
 
 	atomic_init(&t->refcnt, 1);
 	INIT_LIST_HEAD(&t->trans_list_entry);
@@ -375,8 +376,6 @@ int dnet_trans_alloc_send_state(struct dnet_session *s, struct dnet_net_state *s
 	t->priv = ctl->priv;
 	if (s) {
 		t->wait_ts = *dnet_session_get_timeout(s);
-	} else {
-		t->wait_ts = n->wait_ts;
 	}
 
 	cmd = (struct dnet_cmd *)(t + 1);

--- a/library/trans.c
+++ b/library/trans.c
@@ -252,10 +252,12 @@ void dnet_trans_destroy(struct dnet_trans *t)
 
 		pthread_mutex_lock(&st->trans_lock);
 		list_del_init(&t->trans_list_entry);
-		pthread_mutex_unlock(&st->trans_lock);
 
-		if (t->trans_entry.rb_parent_color)
-			dnet_trans_remove(t);
+		if (t->trans_entry.rb_parent_color) {
+			dnet_trans_remove_nolock(st, t);
+		}
+
+		pthread_mutex_unlock(&st->trans_lock);
 	} else if (!list_empty(&t->trans_list_entry)) {
 		assert(0);
 	}

--- a/tests/server_send.cpp
+++ b/tests/server_send.cpp
@@ -249,8 +249,6 @@ static void ssend_test_server_send(session &s, int num, const std::string &id_pr
 	int copied = 0;
 	auto iter = s.server_send(keys, iflags, dst_groups);
 	for (auto it = iter.begin(), iter_end = iter.end(); it != iter_end; ++it) {
-		BOOST_REQUIRE_EQUAL(it->command()->status, 0);
-		BOOST_REQUIRE_EQUAL(it->reply()->status, status);
 #if 0
 		// we have to explicitly convert all members from dnet_iterator_response
 		// since it is packed and there will be alignment issues and
@@ -267,6 +265,8 @@ static void ssend_test_server_send(session &s, int num, const std::string &id_pr
 			(int)it->reply()->status, (unsigned long long)it->reply()->size,
 			(unsigned long long)it->reply()->iterated_keys, (unsigned long long)it->reply()->total_keys);
 #endif
+		BOOST_REQUIRE_EQUAL(it->command()->status, 0);
+		BOOST_REQUIRE_EQUAL(it->reply()->status, status);
 
 		copied++;
 	}
@@ -423,7 +423,7 @@ static bool ssend_register_tests(test_suite *suite, node &n)
 	iflags = 0;
 
 	std::vector<int> delayed_groups{ssend_dst_groups[0]};
-	ELLIPTICS_TEST_CASE(ssend_test_set_delay, src, delayed_groups, 61000);
+	ELLIPTICS_TEST_CASE(ssend_test_set_delay, src, delayed_groups, 121000);
 
 	ELLIPTICS_TEST_CASE(ssend_test_server_send, src_noexception, 1, id_prefix, data_prefix,
 	                    delayed_groups, iflags, -ETIMEDOUT);


### PR DESCRIPTION
Currently neither copy/move iterator nor server-send operation allow setting write command timeout, which is vital for long-distance connections and slow links between groups. This pull request allows to set this parameter from command line options already present in all clients (python and C++ bindings).

This pull request breaks backward compatibility for server-send command, but since our internal tools are the only users of this feature, it should be ok.