### PR TITLE
Dynamic backends

### DIFF
--- a/example/config.hpp
+++ b/example/config.hpp
@@ -354,7 +354,7 @@ struct config_data : public dnet_config_data
 	std::mutex					parser_mutex;
 	std::shared_ptr<config_parser>			parser;
 	dnet_time					config_timestamp;
-	dnet_backend_info_list				backends_guard;
+	dnet_backend_info_manager			backends_guard;
 	std::string					logger_value;
 	ioremap::elliptics::logger_base			logger_base;
 	ioremap::elliptics::logger			logger;
@@ -362,6 +362,8 @@ struct config_data : public dnet_config_data
 	std::unique_ptr<cache::cache_config>		cache_config;
 	std::unique_ptr<monitor::monitor_config>	monitor_config;
 };
+
+std::shared_ptr<dnet_backend_info> dnet_parse_backend(config_data *data, uint32_t backend_id, const config &backend);
 
 } } } // namespace ioremap::elliptics::config
 

--- a/library/backend.h
+++ b/library/backend.h
@@ -58,7 +58,8 @@ struct dnet_backend_info
 
 	dnet_backend_info(dnet_logger &logger, uint32_t backend_id) :
 		log(new dnet_logger(logger, make_attributes(backend_id))),
-		group(0), cache(NULL), enable_at_start(false), read_only_at_start(false),
+		backend_id(backend_id), group(0), cache(NULL),
+		enable_at_start(false), read_only_at_start(false),
 		state_mutex(new std::mutex), state(DNET_BACKEND_UNITIALIZED),
 		io_thread_num(0), nonblocking_io_thread_num(0)
 	{
@@ -75,6 +76,7 @@ struct dnet_backend_info
 		config_template(other.config_template),
 		log(std::move(other.log)),
 		options(std::move(other.options)),
+		backend_id(other.backend_id),
 		group(other.group),
 		cache(other.cache),
 		history(other.history),
@@ -97,6 +99,7 @@ struct dnet_backend_info
 		config_template = other.config_template;
 		log = std::move(other.log);
 		options = std::move(other.options);
+		backend_id = other.backend_id;
 		group = other.group;
 		cache = other.cache;
 		history = other.history;
@@ -120,6 +123,7 @@ struct dnet_backend_info
 	dnet_config_backend config_template;
 	std::unique_ptr<dnet_logger> log;
 	std::vector<dnet_backend_config_entry> options;
+	uint32_t backend_id;
 	uint32_t group;
 	void *cache;
 	std::string history;
@@ -139,14 +143,39 @@ struct dnet_backend_info
 	int nonblocking_io_thread_num;
 };
 
-struct dnet_backend_info_list
+class dnet_backend_info_manager
 {
-	std::vector<dnet_backend_info> backends;
+public:
+	/*
+	 * Locks backend with \a backend_id state mutex and fills \a status
+	 */
+	void backend_fill_status(struct dnet_node *node, struct dnet_backend_status *status, size_t backend_id) const;
+
+	std::vector<std::shared_ptr<dnet_backend_info> > get_all_backends() const
+	{
+		std::vector<std::shared_ptr<dnet_backend_info> > result;
+		std::lock_guard<std::mutex> guard(backends_mutex);
+		for (auto it : backends) {
+			result.push_back(it.second);
+		}
+		return result;
+	}
+
+	std::shared_ptr<dnet_backend_info> get_backend(size_t backend_id) const;
+
+	void add_backend(std::shared_ptr<dnet_backend_info> &backend);
+
+private:
+	std::unordered_map<uint32_t, std::shared_ptr<dnet_backend_info> > backends;
+	mutable std::mutex backends_mutex;
 };
+
+void backend_fill_status_nolock(struct dnet_node *node, struct dnet_backend_status *status, const struct dnet_backend_info *config_backend);
 
 extern "C" {
 #else // __cplusplus
-typedef struct dnet_backend_info_list_t dnet_backend_info_list;
+typedef struct dnet_backend_info_manager dnet_backend_info_manager;
+struct dnet_io;
 #endif // __cplusplus
 
 int dnet_backend_init(struct dnet_node *n, size_t backend_id, int *state);
@@ -155,20 +184,12 @@ int dnet_backend_cleanup(struct dnet_node *n, size_t backend_id, int *state);
 int dnet_backend_init_all(struct dnet_node *n);
 void dnet_backend_cleanup_all(struct dnet_node *n);
 
-size_t dnet_backend_info_list_count(dnet_backend_info_list *backends);
+int dnet_get_backend_ids(const dnet_backend_info_manager *backends, size_t **backend_ids, size_t *num_backend_ids);
 
 int dnet_cmd_backend_control(struct dnet_net_state *st, struct dnet_cmd *cmd, void *data);
 int dnet_cmd_backend_status(struct dnet_net_state *st, struct dnet_cmd *cmd, void *data);
 
-/*
- * Fills \a status of backend with \a backend_id without any locks
- */
-void backend_fill_status_nolock(struct dnet_node *node, struct dnet_backend_status *status, size_t backend_id);
-
-/*
- * Locks backend with \a backend_id state mutex and fills \a status
- */
-void backend_fill_status(struct dnet_node *node, struct dnet_backend_status *status, size_t backend_id);
+struct dnet_backend_io *dnet_get_backend_io(struct dnet_io *io, size_t backend_id);
 
 #ifdef __cplusplus
 }

--- a/library/common.cpp
+++ b/library/common.cpp
@@ -1,6 +1,32 @@
 #include "elliptics.h"
 
-size_t dnet_backend_info_list_count(dnet_backend_info_list *backends)
+int dnet_get_backend_ids(const dnet_backend_info_manager *backends, size_t **backend_ids, size_t *num_backend_ids)
 {
-	return backends ? backends->backends.size() : 0;
+	if (!backends)
+		return -EINVAL;
+
+	auto config_backends = backends->get_all_backends();
+	*num_backend_ids = config_backends.size();
+	*backend_ids = reinterpret_cast<size_t *>(malloc(*num_backend_ids * sizeof(size_t)));
+	if (!*backend_ids)
+		return -ENOMEM;
+
+	for (size_t i = 0; i < *num_backend_ids; ++i) {
+		(*backend_ids)[i] = config_backends[i]->backend_id;
+	}
+
+	return 0;
+}
+
+struct dnet_backend_io *dnet_get_backend_io(struct dnet_io *io, size_t backend_id)
+{
+	struct dnet_backend_io *backend_io = nullptr;
+
+	pthread_rwlock_rdlock(&io->backends_lock);
+	if (backend_id < io->backends_count) {
+		backend_io = io->backends[backend_id];
+	}
+	pthread_rwlock_unlock(&io->backends_lock);
+
+	return backend_io;
 }

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -430,6 +430,7 @@ struct dnet_work_io {
 	int			thread_index;
 	uint64_t		trans;
 	pthread_t		tid;
+	int			joined;
 	struct dnet_work_pool	*pool;
 };
 
@@ -502,9 +503,9 @@ struct dnet_io {
 	struct dnet_net_io	*net;
 
 
-	struct dnet_backend_io	*backends;
+	struct dnet_backend_io	**backends;
 	size_t			backends_count;
-	pthread_mutex_t		backends_lock;
+	pthread_rwlock_t	backends_lock;
 
 	struct dnet_io_pool	pool;
 
@@ -519,6 +520,7 @@ struct dnet_io {
 int dnet_state_accept_process(struct dnet_net_state *st, struct epoll_event *ev);
 int dnet_io_init(struct dnet_node *n, struct dnet_config *cfg);
 void *dnet_io_process(void *data_);
+int dnet_server_backend_init(struct dnet_node *n, size_t backend_id);
 int dnet_server_io_init(struct dnet_node *n);
 /* Set need_exit flag, stop and join pool threads */
 void dnet_io_stop(struct dnet_node *n);
@@ -539,7 +541,7 @@ struct dnet_config_data {
 	int daemon_mode;
 	int parallel_start;
 
-	dnet_backend_info_list *backends;
+	dnet_backend_info_manager *backends;
 };
 
 struct dnet_config_data *dnet_config_data_create();

--- a/library/pool.c
+++ b/library/pool.c
@@ -55,7 +55,10 @@ static void dnet_work_pool_stop(struct dnet_work_pool_place *place)
 
 	for (i = 0; i < place->pool->num; ++i) {
 		wio = &place->pool->wio_list[i];
-		pthread_join(wio->tid, NULL);
+		if (!wio->joined) {
+			pthread_join(wio->tid, NULL);
+			wio->joined = 1;
+		}
 	}
 
 	pthread_mutex_unlock(&place->lock);
@@ -120,6 +123,7 @@ static int dnet_work_pool_grow(struct dnet_node *n, struct dnet_work_pool *pool,
 		wio->thread_index = i;
 		wio->pool = pool;
 		wio->trans = ~0ULL;
+		wio->joined = 0;
 		INIT_LIST_HEAD(&wio->reply_list);
 		INIT_LIST_HEAD(&wio->request_list);
 
@@ -282,6 +286,7 @@ static void dnet_update_trans_timestamp_network(struct dnet_io_req *r)
 
 void dnet_schedule_io(struct dnet_node *n, struct dnet_io_req *r)
 {
+	struct dnet_backend_io *backend_io = NULL;
 	struct dnet_work_pool_place *place = NULL;
 	struct dnet_work_pool_place *backend_place = NULL;
 	struct dnet_work_pool *pool = NULL;
@@ -314,8 +319,12 @@ void dnet_schedule_io(struct dnet_node *n, struct dnet_io_req *r)
 	else if (dnet_cmd_needs_backend(cmd->cmd))
 		backend_id = dnet_state_search_backend(n, &cmd->id);
 
-	if (backend_id >= 0 && backend_id < (ssize_t)n->io->backends_count) {
-		io_pool = &n->io->backends[backend_id].pool;
+	if (backend_id >= 0) {
+		backend_io = dnet_get_backend_io(n->io, backend_id);
+	}
+
+	if (backend_io) {
+		io_pool = &backend_io->pool;
 		if (nonblocking) {
 			place = &io_pool->recv_pool_nb;
 		} else {
@@ -822,15 +831,19 @@ static int dnet_check_io(struct dnet_io *io)
 {
 	uint64_t list_size = 0;
 	uint64_t threads_count = 0;
+	size_t i;
 
 	dnet_check_io_pool(&io->pool, &list_size, &threads_count);
 
+	pthread_rwlock_rdlock(&io->backends_lock);
 	if (io->backends) {
-		size_t i;
 		for (i = 0; i < io->backends_count; ++i) {
-			dnet_check_io_pool(&io->backends[i].pool, &list_size, &threads_count);
+			if (io->backends[i]) {
+				dnet_check_io_pool(&io->backends[i]->pool, &list_size, &threads_count);
+			}
 		}
 	}
+	pthread_rwlock_unlock(&io->backends_lock);
 
 	if (list_size <= threads_count * 1000)
 		return 1;
@@ -1098,7 +1111,7 @@ int dnet_io_init(struct dnet_node *n, struct dnet_config *cfg)
 		goto err_out_free_mutex;
 	}
 
-	err = pthread_mutex_init(&n->io->backends_lock, NULL);
+	err = pthread_rwlock_init(&n->io->backends_lock, NULL);
 	if (err) {
 		err = -err;
 		goto err_out_free_cond;
@@ -1172,7 +1185,7 @@ err_out_free_recv_pool:
 err_out_cleanup_recv_place:
 	dnet_work_pool_place_cleanup(&n->io->pool.recv_pool);
 err_out_free_backends_lock:
-	pthread_mutex_destroy(&n->io->backends_lock);
+	pthread_rwlock_destroy(&n->io->backends_lock);
 err_out_free_cond:
 	pthread_cond_destroy(&n->io->full_wait);
 err_out_free_mutex:
@@ -1184,46 +1197,129 @@ err_out_exit:
 	return err;
 }
 
-int dnet_server_io_init(struct dnet_node *n)
+int dnet_server_backend_init(struct dnet_node *n, size_t backend_id)
 {
 	int err;
-	size_t j = 0, k = 0;
+	const size_t new_count = backend_id + 1;
+	struct dnet_backend_io **backends_tmp;
+	struct dnet_backend_io *io;
 
-	n->io->backends_count = dnet_backend_info_list_count(n->config_data->backends);
-	n->io->backends = calloc(n->io->backends_count, sizeof(struct dnet_backend_io));
-	if (!n->io->backends) {
-		err = -ENOMEM;
-		goto err_out_exit;
-	}
+	pthread_rwlock_wrlock(&n->io->backends_lock);
+	if (new_count > n->io->backends_count || !n->io->backends[backend_id]) {
+		io = calloc(1, sizeof(struct dnet_backend_io));
+		if (!io) {
+			err = -ENOMEM;
+			goto err_out_unlock;
+		}
 
-	for (j = 0; j < n->io->backends_count; ++j) {
-		struct dnet_backend_io *io = &n->io->backends[j];
-		io->backend_id = j;
+		io->backend_id = backend_id;
 
 		err = dnet_work_pool_place_init(&io->pool.recv_pool);
 		if (err) {
-			goto err_out_free_backends_io;
+			goto err_out_free;
 		}
 
 		err = dnet_work_pool_place_init(&io->pool.recv_pool_nb);
 		if (err) {
 			dnet_work_pool_place_cleanup(&io->pool.recv_pool);
+			goto err_out_free;
+		}
+
+		if (new_count > n->io->backends_count) {
+			backends_tmp = realloc(n->io->backends, new_count * sizeof(struct dnet_backend_io *));
+			if (backends_tmp) {
+				memset(backends_tmp + n->io->backends_count, 0,
+				       (new_count - n->io->backends_count) * sizeof(struct dnet_backend_io *));
+				n->io->backends = backends_tmp;
+				n->io->backends_count = new_count;
+			} else {
+				err = -ENOMEM;
+				goto err_out_free;
+			}
+		}
+
+		n->io->backends[backend_id] = io;
+	}
+	pthread_rwlock_unlock(&n->io->backends_lock);
+
+	return 0;
+
+err_out_free:
+	free(io);
+err_out_unlock:
+	pthread_rwlock_unlock(&n->io->backends_lock);
+	return err;
+}
+
+int dnet_server_io_init(struct dnet_node *n)
+{
+	int err;
+	size_t j = 0, k = 0;
+	size_t *backend_ids, num_backend_ids;
+	size_t backends_count;
+
+        err = dnet_get_backend_ids(n->config_data->backends, &backend_ids, &num_backend_ids);
+	if (err) {
+		goto err_out_exit;
+	}
+
+	backends_count = backend_ids[0];
+	for (j = 1; j < num_backend_ids; ++j) {
+		if (backend_ids[0] > backends_count)
+			backends_count = backend_ids[0];
+	}
+	++backends_count;
+
+	n->io->backends_count = backends_count;
+	n->io->backends = calloc(backends_count, sizeof(struct dnet_backend_io *));
+	if (!n->io->backends) {
+		err = -ENOMEM;
+		goto err_out_free_backend_ids;
+	}
+
+	for (j = 0; j < num_backend_ids; ++j) {
+		struct dnet_backend_io *io = calloc(1, sizeof(struct dnet_backend_io));
+		if (!io) {
+			err = -ENOMEM;
 			goto err_out_free_backends_io;
 		}
+
+		io->backend_id = backend_ids[j];
+
+		err = dnet_work_pool_place_init(&io->pool.recv_pool);
+		if (err) {
+			free(io);
+			goto err_out_free_backends_io;
+		}
+
+		err = dnet_work_pool_place_init(&io->pool.recv_pool_nb);
+		if (err) {
+			free(io);
+			dnet_work_pool_place_cleanup(&io->pool.recv_pool);
+			goto err_out_free_backends_io;
+		}
+
+		n->io->backends[io->backend_id] = io;
 	}
+
+	free(backend_ids);
 	return 0;
 
 err_out_free_backends_io:
 	for (k = 0; k < j; ++k) {
-		struct dnet_backend_io *io = &n->io->backends[k];
-		io->need_exit = 1;
+		struct dnet_backend_io *backend_io = n->io->backends[backend_ids[k]];
+		backend_io->need_exit = 1;
 	}
 	for (k = 0; k < j; ++k) {
-		struct dnet_backend_io *io = &n->io->backends[k];
-		dnet_work_pool_exit(&io->pool.recv_pool);
-		dnet_work_pool_exit(&io->pool.recv_pool_nb);
+		struct dnet_backend_io *backend_io = n->io->backends[backend_ids[k]];
+		dnet_work_pool_exit(&backend_io->pool.recv_pool);
+		dnet_work_pool_exit(&backend_io->pool.recv_pool_nb);
+		free(backend_io);
 	}
 	free(n->io->backends);
+	n->io->backends = NULL;
+err_out_free_backend_ids:
+	free(backend_ids);
 err_out_exit:
 	return err;
 }
@@ -1237,11 +1333,13 @@ void dnet_io_stop(struct dnet_node *n)
 	dnet_set_need_exit(n);
 
 	for (j = 0; j < n->io->backends_count; ++j) {
-		struct dnet_backend_io *backend_io = &n->io->backends[j];
-		backend_io->need_exit = 1;
+		struct dnet_backend_io *backend_io = n->io->backends[j];
+		if (backend_io) {
+			backend_io->need_exit = 1;
+		}
 	}
 
-	for (i=0; i<io->net_thread_num; ++i) {
+	for (i = 0; i < io->net_thread_num; ++i) {
 		pthread_join(io->net[i].tid, NULL);
 		close(io->net[i].epoll_fd);
 	}
@@ -1250,11 +1348,13 @@ void dnet_io_stop(struct dnet_node *n)
 	dnet_work_pool_stop(&io->pool.recv_pool);
 
 	for (j = 0; j < io->backends_count; ++j) {
-		struct dnet_backend_io *backend_io = &io->backends[j];
-		if (backend_io->pool.recv_pool.pool)
-			dnet_work_pool_stop(&backend_io->pool.recv_pool);
-		if (backend_io->pool.recv_pool_nb.pool)
-			dnet_work_pool_stop(&backend_io->pool.recv_pool_nb);
+		struct dnet_backend_io *backend_io = io->backends[j];
+		if (backend_io) {
+			if (backend_io->pool.recv_pool.pool)
+				dnet_work_pool_stop(&backend_io->pool.recv_pool);
+			if (backend_io->pool.recv_pool_nb.pool)
+				dnet_work_pool_stop(&backend_io->pool.recv_pool_nb);
+		}
 	}
 }
 
@@ -1270,14 +1370,21 @@ void dnet_io_cleanup(struct dnet_node *n)
 	dnet_work_pool_place_cleanup(&io->pool.recv_pool);
 
 	for (i = 0; i < io->backends_count; ++i) {
-		struct dnet_backend_io *backend_io = &io->backends[i];
-		if (backend_io->pool.recv_pool.pool)
-			dnet_work_pool_cleanup(&backend_io->pool.recv_pool);
-		if (backend_io->pool.recv_pool_nb.pool)
-			dnet_work_pool_cleanup(&backend_io->pool.recv_pool_nb);
-		dnet_work_pool_place_cleanup(&backend_io->pool.recv_pool_nb);
-		dnet_work_pool_place_cleanup(&backend_io->pool.recv_pool);
+		struct dnet_backend_io *backend_io = io->backends[i];
+		if (backend_io) {
+			if (backend_io->pool.recv_pool.pool)
+				dnet_work_pool_cleanup(&backend_io->pool.recv_pool);
+			if (backend_io->pool.recv_pool_nb.pool)
+				dnet_work_pool_cleanup(&backend_io->pool.recv_pool_nb);
+			dnet_work_pool_place_cleanup(&backend_io->pool.recv_pool_nb);
+			dnet_work_pool_place_cleanup(&backend_io->pool.recv_pool);
+
+			free(backend_io);
+			io->backends[i] = NULL;
+		}
 	}
+	free(io->backends);
+	io->backends = NULL;
 
 	dnet_io_cleanup_states(n);
 

--- a/library/server.c
+++ b/library/server.c
@@ -231,12 +231,12 @@ void dnet_server_node_destroy(struct dnet_node *n)
 	 */
 	dnet_monitor_exit(n);
 
-	dnet_node_cleanup_common_resources(n);
-
 	dnet_route_list_destroy(n->route);
 	n->route = NULL;
 
 	dnet_backend_cleanup_all(n);
+
+	dnet_node_cleanup_common_resources(n);
 
 	dnet_srw_cleanup(n);
 

--- a/tests/cache_test.cpp
+++ b/tests/cache_test.cpp
@@ -84,7 +84,8 @@ static void test_cache_timestamp(session &sess)
 static void test_cache_records_sizes(session &sess)
 {
 	dnet_node *node = global_data->nodes[0].get_native();
-	ioremap::cache::cache_manager *cache = (ioremap::cache::cache_manager*) node->io->backends[0].cache;
+	dnet_backend_io *backend_io = dnet_get_backend_io(node->io, 0);
+	ioremap::cache::cache_manager *cache = reinterpret_cast<ioremap::cache::cache_manager *>(backend_io->cache);
 	const size_t cache_size = cache->cache_size();
 	const size_t cache_pages_number = cache->cache_pages_number();
 	argument_data data("0");
@@ -117,7 +118,8 @@ static void test_cache_records_sizes(session &sess)
 static void test_cache_overflow(session &sess)
 {
 	dnet_node *node = global_data->nodes[0].get_native();
-	ioremap::cache::cache_manager *cache = (ioremap::cache::cache_manager*) node->io->backends[0].cache;
+	dnet_backend_io *backend_io = dnet_get_backend_io(node->io, 0);
+	ioremap::cache::cache_manager *cache = reinterpret_cast<ioremap::cache::cache_manager *>(backend_io->cache);
 	const size_t cache_size = cache->cache_size();
 	const size_t cache_pages_number = cache->cache_pages_number();
 	argument_data data("0");
@@ -236,7 +238,8 @@ void cache_read_check_lru(session &sess, int id, lru_list_emulator_t& lru_list_e
 static void test_cache_lru_eviction(session &sess)
 {
 	dnet_node *node = global_data->nodes[0].get_native();
-	ioremap::cache::cache_manager *cache = (ioremap::cache::cache_manager*) node->io->backends[0].cache;
+	dnet_backend_io *backend_io = dnet_get_backend_io(node->io, 0);
+	ioremap::cache::cache_manager *cache = reinterpret_cast<ioremap::cache::cache_manager *>(backend_io->cache);
 	const size_t cache_size = cache->cache_size();
 	const size_t cache_pages_number = cache->cache_pages_number();
 

--- a/tests/test_base.cpp
+++ b/tests/test_base.cpp
@@ -105,6 +105,11 @@ void create_directory(const std::string &path)
 
 #ifndef NO_SERVER
 
+config_data::config_data()
+: m_serializable(true)
+{
+}
+
 config_data &config_data::operator() (const std::string &name, const std::vector<std::string> &value)
 {
 	return (*this)(name, variant(value));
@@ -166,6 +171,16 @@ std::string config_data::string_value(const std::string &name) const
 {
 	auto value = value_impl(name);
 	return value ? boost::apply_visitor(stringify_visitor(), *value) : std::string();
+}
+
+void config_data::set_serializable(bool serializable)
+{
+	m_serializable = serializable;
+}
+
+bool config_data::is_serializable() const
+{
+	return m_serializable;
 }
 
 config_data::const_iterator config_data::cbegin() const
@@ -380,6 +395,9 @@ void server_config::write(const std::string &path)
 	backends_json.SetArray();
 
 	for (auto it = backends.begin(); it != backends.end(); ++it) {
+		if (!it->is_serializable())
+			continue;
+
 		rapidjson::Value backend;
 		backend.SetObject();
 
@@ -562,7 +580,7 @@ std::string server_node::config_path() const
 	return m_path;
 }
 
-server_config server_node::config() const
+server_config &server_node::config()
 {
 	return m_config;
 }
@@ -816,13 +834,6 @@ nodes_data::ptr start_nodes(start_nodes_config &start_config) {
 
 		create_directory(server_path);
 
-		for (size_t j = 0; j < config.backends.size(); ++j) {
-			std::string prefix = server_path + "/" + boost::lexical_cast<std::string>(j);
-			create_directory(prefix);
-			create_directory(prefix + "/history");
-			create_directory(prefix + "/blob");
-		}
-
 		std::vector<std::string> remotes;
 		for (size_t j = 0; j < start_config.configs.size(); ++j) {
 			if (j == i)
@@ -871,7 +882,11 @@ nodes_data::ptr start_nodes(start_nodes_config &start_config) {
 				;
 
 		for (size_t i = 0; i < config.backends.size(); ++i) {
-			std::string prefix = server_path + "/" + boost::lexical_cast<std::string>(i);
+			std::string prefix = server_path + '/' + std::to_string(i);
+			create_directory(prefix);
+			create_directory(prefix + "/history");
+			create_directory(prefix + "/blob");
+
 			config.backends[i]
 					("history", prefix + "/history")
 					("data", prefix + "/blob")

--- a/tests/test_base.hpp
+++ b/tests/test_base.hpp
@@ -135,6 +135,8 @@ protected:
 	typedef std::vector<std::pair<std::string, variant> > container_t;
 
 public:
+	config_data();
+
 	config_data &operator() (const std::string &name, const std::vector<std::string> &value);
 	config_data &operator() (const std::string &name, const std::string &value);
 	config_data &operator() (const std::string &name, const char *value);
@@ -146,6 +148,9 @@ public:
 	bool has_value(const std::string &name) const;
 	std::string string_value(const std::string &name) const;
 
+	void set_serializable(bool serializable);
+	bool is_serializable() const;
+
 	typedef container_t::const_iterator const_iterator;
 	const_iterator cbegin() const;
 	const_iterator cend() const;
@@ -154,6 +159,7 @@ protected:
 	config_data &operator() (const std::string &name, const variant &value);
 	const variant *value_impl(const std::string &name) const;
 
+	bool m_serializable;
 	container_t m_data;
 	friend class server_config;
 };
@@ -193,7 +199,7 @@ public:
 	bool is_stopped() const;
 
 	std::string config_path() const;
-	server_config config() const;
+	server_config &config();
 
 	address remote() const;
 	int monitor_port() const;


### PR DESCRIPTION
Server parses config and starts backend, which was not presented in config initially, on DNET_BACKEND_ENABLE command. Thus, it is possible to add backends on the fly.