### PR TITLE
net: fix addicting net thread on sending responses to one state

### DIFF
--- a/library/pool.c
+++ b/library/pool.c
@@ -689,6 +689,7 @@ static int dnet_process_send_single(struct dnet_net_state *st)
 
 			dnet_io_req_free(r);
 			st->send_offset = 0;
+			break;
 		}
 
 		if (err)


### PR DESCRIPTION
If there are a lot of small responses which should be sent to some state with good connection, e.g. iterator generates such responses, net thread can get into cycle of sending these responses and will not send responses to other states until cycle is done. If responses is rather small, the cycle will be done only when all responses are sent.

I've added break to this cycle if a response is fully sent, so net thread will switch to another state for sending response to it.